### PR TITLE
[FEAT] Implement Candidate Event Review Screen (Issue #12)

### DIFF
--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -1,0 +1,199 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.quarterLabel {
+  font-size: 13px;
+  color: #718096;
+  margin: 0;
+}
+
+.cardRow {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.section {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 20px 24px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.sectionHeader h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.section h3 {
+  margin: 0 0 16px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.viewAll {
+  background: none;
+  border: none;
+  color: #3182ce;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.viewAll:hover {
+  text-decoration: underline;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid #e2e8f0;
+  color: #718096;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #f0f4f8;
+  color: #2d3748;
+}
+
+.row {
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.row:hover {
+  background-color: #f7fafc;
+}
+
+.eventId {
+  font-family: monospace;
+  font-size: 12px;
+  color: #3182ce;
+  font-weight: 600;
+}
+
+.empty {
+  color: #a0aec0;
+  font-size: 13px;
+  margin: 0;
+}
+
+/* PPE type bars */
+.ppeRow {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.ppeCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ppeCardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ppeName {
+  font-size: 14px;
+  font-weight: 600;
+  color: #2d3748;
+}
+
+.ppeCount {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a202c;
+}
+
+.ppeBar {
+  height: 8px;
+  background: #edf2f7;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.ppeBarFill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.ppeScore {
+  font-size: 11px;
+  color: #a0aec0;
+}
+
+/* Zone ranking list */
+.zoneList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.zoneItem {
+  display: grid;
+  grid-template-columns: 24px 1fr 1fr 48px;
+  align-items: center;
+  gap: 12px;
+}
+
+.zoneRank {
+  font-size: 12px;
+  font-weight: 700;
+  color: #a0aec0;
+}
+
+.zoneName {
+  font-size: 13px;
+  color: #2d3748;
+}
+
+.zoneBarWrap {
+  height: 6px;
+  background: #edf2f7;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.zoneBarFill {
+  height: 100%;
+  background: #3182ce;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.zoneCount {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a202c;
+  text-align: right;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,3 +1,125 @@
+import { useNavigate } from 'react-router-dom';
+import { useOutletContext } from 'react-router-dom';
+import SummaryCard from '../components/SummaryCard';
+import StatusBadge from '../components/StatusBadge';
+import { MOCK_QUARTERLY_STATS, MOCK_EVENTS } from '../mock';
+import styles from './HomePage.module.css';
+
 export default function HomePage() {
-  return <div>홈 요약</div>;
+  const { quarter } = useOutletContext<{ quarter: string }>();
+  const navigate = useNavigate();
+  const stats = MOCK_QUARTERLY_STATS;
+  // Show only pending events on the home page as priority items
+  const pendingEvents = MOCK_EVENTS.filter((e) => e.event_status === 'pending');
+
+  return (
+    <div className={styles.page}>
+      <p className={styles.quarterLabel}>{quarter} 기준</p>
+
+      <div className={styles.cardRow}>
+        <SummaryCard label="후보 이벤트" value={stats.summary.candidate_count} sub="AI 추출 총합" />
+        <SummaryCard label="확정 위반" value={stats.summary.confirmed_count} sub="검토 완료" trend={12} />
+        <SummaryCard label="오탐" value={stats.summary.false_positive_count} sub="AI 오탐지" trend={-5} />
+        <SummaryCard label="보류" value={stats.summary.hold_count} sub="추가 검토 필요" />
+      </div>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h3>미검토 이벤트 ({pendingEvents.length}건)</h3>
+          <button className={styles.viewAll} onClick={() => navigate('/review')}>
+            전체 보기 →
+          </button>
+        </div>
+        {pendingEvents.length === 0 ? (
+          <p className={styles.empty}>미검토 이벤트가 없습니다.</p>
+        ) : (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>이벤트 ID</th>
+                <th>발생 일시</th>
+                <th>구역</th>
+                <th>PPE 유형</th>
+                <th>신뢰도</th>
+                <th>상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pendingEvents.map((event) => (
+                <tr
+                  key={event.event_id}
+                  className={styles.row}
+                  onClick={() => navigate(`/review/${event.event_id}`)}
+                >
+                  <td className={styles.eventId}>{event.event_id}</td>
+                  <td>
+                    {new Date(event.timestamp_start).toLocaleString('ko-KR', {
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td>{event.zone_name}</td>
+                  <td>{event.ppe_type === 'helmet' ? '안전모' : '안전조끼'}</td>
+                  <td>{(event.ai_confidence * 100).toFixed(0)}%</td>
+                  <td>
+                    <StatusBadge status={event.event_status} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className={styles.section}>
+        <h3>PPE 유형별 위반 현황</h3>
+        <div className={styles.ppeRow}>
+          {stats.by_ppe_type.map((p) => (
+            <div key={p.ppe_type} className={styles.ppeCard}>
+              <div className={styles.ppeCardHeader}>
+                <span className={styles.ppeName}>
+                  {p.ppe_type === 'helmet' ? '🪖 안전모' : '🦺 안전조끼'}
+                </span>
+                <span className={styles.ppeCount}>{p.confirmed_count}건</span>
+              </div>
+              <div className={styles.ppeBar}>
+                {/* Width proportional to share of total confirmed violations */}
+                <div
+                  className={styles.ppeBarFill}
+                  style={{
+                    width: `${(p.confirmed_count / stats.summary.confirmed_count) * 100}%`,
+                    backgroundColor: p.ppe_type === 'helmet' ? '#e53e3e' : '#d69e2e',
+                  }}
+                />
+              </div>
+              <span className={styles.ppeScore}>우선순위 점수 {p.priority_score}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h3>구역별 위반 현황</h3>
+        <div className={styles.zoneList}>
+          {stats.by_zone.map((z, idx) => (
+            <div key={z.zone_name} className={styles.zoneItem}>
+              <span className={styles.zoneRank}>#{idx + 1}</span>
+              <span className={styles.zoneName}>{z.zone_name}</span>
+              <div className={styles.zoneBarWrap}>
+                <div
+                  className={styles.zoneBarFill}
+                  style={{
+                    width: `${(z.confirmed_count / stats.by_zone[0].confirmed_count) * 100}%`,
+                  }}
+                />
+              </div>
+              <span className={styles.zoneCount}>{z.confirmed_count}건</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/frontend/src/pages/ReviewDetailPage.module.css
+++ b/frontend/src/pages/ReviewDetailPage.module.css
@@ -1,0 +1,328 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.backBtn {
+  background: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: #4a5568;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.backBtn:hover {
+  background: #f7fafc;
+}
+
+.eventLabel {
+  font-family: monospace;
+  font-weight: 700;
+  color: #1a202c;
+  font-size: 15px;
+}
+
+/* Two-column layout: left = media, right = info + form */
+.grid {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.mediaCol {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.infoCol {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Shared card style */
+.card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.cardTitle {
+  margin: 0 0 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a202c;
+  border-bottom: 1px solid #f0f4f8;
+  padding-bottom: 10px;
+}
+
+/* Thumbnail zone */
+.thumbnail {
+  background: #1a202c;
+  border-radius: 8px;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.thumbnailPlaceholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: #718096;
+}
+
+.thumbnailIcon {
+  font-size: 40px;
+}
+
+.thumbnailPlaceholder p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.thumbnailPlaceholder small {
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+/* Definition list for event details */
+.dl {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 8px 12px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.dl dt {
+  color: #718096;
+  align-self: center;
+}
+
+.dl dd {
+  margin: 0;
+  color: #1a202c;
+  font-weight: 500;
+  align-self: center;
+}
+
+.clipPath {
+  font-family: monospace;
+  font-size: 11px;
+  word-break: break-all;
+  color: #a0aec0;
+}
+
+/* Confidence level coloring */
+.confidenceValue {
+  font-weight: 700;
+}
+
+.high {
+  color: #38a169;
+}
+
+.mid {
+  color: #d69e2e;
+}
+
+.low {
+  color: #e53e3e;
+}
+
+/* Review result toggle buttons */
+.resultButtons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.resultBtn {
+  padding: 10px;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.12s;
+  background: #f7fafc;
+  color: #4a5568;
+}
+
+/* Default idle colors */
+.confirmedBtn:hover {
+  border-color: #e53e3e;
+  color: #e53e3e;
+}
+
+.falsePosBtn:hover {
+  border-color: #3182ce;
+  color: #3182ce;
+}
+
+.holdBtn:hover {
+  border-color: #d69e2e;
+  color: #d69e2e;
+}
+
+/* Active / selected state */
+.activeConfirmed {
+  background: #fff5f5;
+  border-color: #e53e3e;
+  color: #e53e3e;
+}
+
+.activeFalsePos {
+  background: #ebf8ff;
+  border-color: #3182ce;
+  color: #3182ce;
+}
+
+.activeHold {
+  background: #fffff0;
+  border-color: #d69e2e;
+  color: #d69e2e;
+}
+
+/* Form fields */
+.field {
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: #4a5568;
+}
+
+.optional {
+  font-weight: 400;
+  color: #a0aec0;
+}
+
+.select,
+.textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #1a202c;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.select:disabled {
+  background: #f7fafc;
+  color: #a0aec0;
+}
+
+.textarea {
+  resize: vertical;
+  font-family: inherit;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #2d3748;
+  cursor: pointer;
+  margin-bottom: 16px;
+}
+
+/* Action buttons row */
+.actionRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.primaryBtn {
+  padding: 9px 18px;
+  background: #3182ce;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: #2b6cb0;
+}
+
+.primaryBtn:disabled {
+  background: #bee3f8;
+  cursor: not-allowed;
+}
+
+.secondaryBtn {
+  padding: 9px 16px;
+  background: #fff;
+  color: #4a5568;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.secondaryBtn:hover {
+  background: #f7fafc;
+}
+
+/* Post-submit confirmation card */
+.submittedCard {
+  background: #f0fff4;
+  border: 1px solid #9ae6b4;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.submittedMsg {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #276749;
+}
+
+/* 404-style not found state */
+.notFound {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px;
+  color: #718096;
+}

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -1,3 +1,249 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import StatusBadge from '../components/StatusBadge';
+import { MOCK_EVENTS } from '../mock';
+import type { ReviewResult, ReviewReasonCode } from '../types';
+import styles from './ReviewDetailPage.module.css';
+
+// Reason code options grouped by the review result selection
+const REASON_OPTIONS: Record<ReviewResult, { value: ReviewReasonCode; label: string }[]> = {
+  confirmed: [
+    { value: 'confirmed_no_helmet', label: '안전모 미착용 확인' },
+    { value: 'confirmed_no_vest', label: '안전조끼 미착용 확인' },
+  ],
+  false_positive: [
+    { value: 'false_positive_occlusion', label: '가림 현상 (오탐)' },
+    { value: 'false_positive_angle', label: '촬영 각도 오류 (오탐)' },
+  ],
+  hold: [
+    { value: 'hold_unclear', label: '영상 불명확' },
+    { value: 'hold_low_resolution', label: '해상도 부족' },
+  ],
+};
+
 export default function ReviewDetailPage() {
-  return <div>이벤트 상세 검토</div>;
+  const { event_id } = useParams<{ event_id: string }>();
+  const navigate = useNavigate();
+
+  const eventIndex = MOCK_EVENTS.findIndex((e) => e.event_id === event_id);
+  const event = MOCK_EVENTS[eventIndex];
+
+  const [reviewResult, setReviewResult] = useState<ReviewResult | null>(null);
+  const [reasonCode, setReasonCode] = useState<ReviewReasonCode | ''>('');
+  const [comment, setComment] = useState('');
+  const [secondReview, setSecondReview] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  if (!event) {
+    return (
+      <div className={styles.notFound}>
+        <p>이벤트를 찾을 수 없습니다. (ID: {event_id})</p>
+        <button onClick={() => navigate('/review')}>목록으로 돌아가기</button>
+      </div>
+    );
+  }
+
+  // Next event in the list for sequential review workflow
+  const nextEvent = eventIndex < MOCK_EVENTS.length - 1 ? MOCK_EVENTS[eventIndex + 1] : null;
+
+  const handleResultClick = (result: ReviewResult) => {
+    setReviewResult(result);
+    setReasonCode(''); // reset reason when the main result changes
+  };
+
+  const handleSubmit = () => {
+    if (!reviewResult || !reasonCode) return;
+    // In production: POST /api/reviews/{event_id} with ReviewRequest body
+    console.log({ event_id, reviewResult, reasonCode, comment, secondReview });
+    setSubmitted(true);
+  };
+
+  const goToNext = () => {
+    if (!nextEvent) return;
+    setReviewResult(null);
+    setReasonCode('');
+    setComment('');
+    setSecondReview(false);
+    setSubmitted(false);
+    navigate(`/review/${nextEvent.event_id}`);
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.breadcrumb}>
+        <button className={styles.backBtn} onClick={() => navigate('/review')}>
+          ← 목록
+        </button>
+        <span className={styles.eventLabel}>{event.event_id}</span>
+        <StatusBadge status={event.event_status} />
+      </div>
+
+      <div className={styles.grid}>
+        {/* Left: thumbnail placeholder + media metadata */}
+        <div className={styles.mediaCol}>
+          <div className={styles.thumbnail}>
+            {event.thumbnail_path ? (
+              <img src={event.thumbnail_path} alt="이벤트 썸네일" />
+            ) : (
+              <div className={styles.thumbnailPlaceholder}>
+                <span className={styles.thumbnailIcon}>📷</span>
+                <p>썸네일 미리보기</p>
+                <small>{event.camera_id}</small>
+              </div>
+            )}
+          </div>
+
+          <div className={styles.card}>
+            <h4 className={styles.cardTitle}>영상 정보</h4>
+            <dl className={styles.dl}>
+              <dt>카메라 ID</dt>
+              <dd>{event.camera_id}</dd>
+              <dt>샘플 프레임 수</dt>
+              <dd>{event.frame_sample_count}프레임</dd>
+              <dt>모델 버전</dt>
+              <dd>{event.model_version}</dd>
+              <dt>클립 경로</dt>
+              <dd className={styles.clipPath}>{event.video_clip_path || '—'}</dd>
+            </dl>
+          </div>
+        </div>
+
+        {/* Right: event details + review form */}
+        <div className={styles.infoCol}>
+          <div className={styles.card}>
+            <h4 className={styles.cardTitle}>이벤트 정보</h4>
+            <dl className={styles.dl}>
+              <dt>발생 일시</dt>
+              <dd>{new Date(event.timestamp_start).toLocaleString('ko-KR')}</dd>
+              <dt>종료 일시</dt>
+              <dd>{new Date(event.timestamp_end).toLocaleString('ko-KR')}</dd>
+              <dt>지속 시간</dt>
+              <dd>{event.duration_sec}초</dd>
+              <dt>구역</dt>
+              <dd>{event.zone_name}</dd>
+              <dt>공정</dt>
+              <dd>{event.process_type}</dd>
+              <dt>PPE 유형</dt>
+              <dd>{event.ppe_type === 'helmet' ? '안전모' : '안전조끼'}</dd>
+              <dt>AI 신뢰도</dt>
+              <dd>
+                <span
+                  className={`${styles.confidenceValue} ${
+                    event.ai_confidence >= 0.85
+                      ? styles.high
+                      : event.ai_confidence >= 0.7
+                        ? styles.mid
+                        : styles.low
+                  }`}
+                >
+                  {(event.ai_confidence * 100).toFixed(1)}%
+                </span>
+              </dd>
+            </dl>
+          </div>
+
+          {submitted ? (
+            <div className={styles.submittedCard}>
+              <p className={styles.submittedMsg}>✅ 검토가 제출되었습니다.</p>
+              <div className={styles.actionRow}>
+                <button className={styles.secondaryBtn} onClick={() => navigate('/review')}>
+                  ← 목록으로
+                </button>
+                {nextEvent && (
+                  <button className={styles.primaryBtn} onClick={goToNext}>
+                    다음 이벤트 →
+                  </button>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className={styles.card}>
+              <h4 className={styles.cardTitle}>검토 입력</h4>
+
+              {/* Three-button toggle for review result */}
+              <div className={styles.resultButtons}>
+                <button
+                  className={`${styles.resultBtn} ${styles.confirmedBtn} ${reviewResult === 'confirmed' ? styles.activeConfirmed : ''}`}
+                  onClick={() => handleResultClick('confirmed')}
+                >
+                  ✓ 확정 위반
+                </button>
+                <button
+                  className={`${styles.resultBtn} ${styles.falsePosBtn} ${reviewResult === 'false_positive' ? styles.activeFalsePos : ''}`}
+                  onClick={() => handleResultClick('false_positive')}
+                >
+                  ✕ 오탐
+                </button>
+                <button
+                  className={`${styles.resultBtn} ${styles.holdBtn} ${reviewResult === 'hold' ? styles.activeHold : ''}`}
+                  onClick={() => handleResultClick('hold')}
+                >
+                  ⏸ 보류
+                </button>
+              </div>
+
+              {/* Reason code dropdown — options depend on the selected result */}
+              <div className={styles.field}>
+                <label className={styles.fieldLabel}>판단 사유</label>
+                <select
+                  className={styles.select}
+                  value={reasonCode}
+                  onChange={(e) => setReasonCode(e.target.value as ReviewReasonCode)}
+                  disabled={!reviewResult}
+                >
+                  <option value="">-- 사유 선택 --</option>
+                  {reviewResult &&
+                    REASON_OPTIONS[reviewResult].map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                </select>
+              </div>
+
+              <div className={styles.field}>
+                <label className={styles.fieldLabel}>
+                  검토 의견 <span className={styles.optional}>(선택)</span>
+                </label>
+                <textarea
+                  className={styles.textarea}
+                  rows={3}
+                  placeholder="추가 의견을 입력하세요..."
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                />
+              </div>
+
+              <label className={styles.checkboxLabel}>
+                <input
+                  type="checkbox"
+                  checked={secondReview}
+                  onChange={(e) => setSecondReview(e.target.checked)}
+                />
+                2차 검토 요청
+              </label>
+
+              <div className={styles.actionRow}>
+                <button className={styles.secondaryBtn} onClick={() => navigate('/review')}>
+                  취소
+                </button>
+                {nextEvent && (
+                  <button className={styles.secondaryBtn} onClick={goToNext}>
+                    다음 이벤트 →
+                  </button>
+                )}
+                <button
+                  className={styles.primaryBtn}
+                  disabled={!reviewResult || !reasonCode}
+                  onClick={handleSubmit}
+                >
+                  검토 제출
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/pages/ReviewListPage.module.css
+++ b/frontend/src/pages/ReviewListPage.module.css
@@ -1,0 +1,115 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pendingBanner {
+  background-color: #fffbeb;
+  border: 1px solid #f6e05e;
+  border-radius: 6px;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: #744210;
+}
+
+.tableWrapper {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th {
+  text-align: left;
+  padding: 10px 14px;
+  background: #f7fafc;
+  border-bottom: 2px solid #e2e8f0;
+  color: #718096;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 11px 14px;
+  border-bottom: 1px solid #f0f4f8;
+  color: #2d3748;
+  vertical-align: middle;
+}
+
+.row {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.row:hover {
+  background-color: #f7fafc;
+}
+
+/* highlight unreviewed rows with a subtle left border */
+.pendingRow {
+  border-left: 3px solid #d69e2e;
+}
+
+.eventId {
+  font-family: monospace;
+  font-size: 12px;
+  color: #3182ce;
+  font-weight: 600;
+}
+
+/* PPE type tags */
+.ppeTag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.helmet {
+  background: #fff5f5;
+  color: #e53e3e;
+}
+
+.vest {
+  background: #fffff0;
+  color: #d69e2e;
+}
+
+/* Confidence coloring */
+.confidence {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.high {
+  color: #38a169;
+}
+
+.mid {
+  color: #d69e2e;
+}
+
+.low {
+  color: #e53e3e;
+}
+
+.empty {
+  text-align: center;
+  color: #a0aec0;
+  padding: 24px;
+}
+
+.count {
+  font-size: 12px;
+  color: #a0aec0;
+  text-align: right;
+  margin: 0;
+}

--- a/frontend/src/pages/ReviewListPage.tsx
+++ b/frontend/src/pages/ReviewListPage.tsx
@@ -1,3 +1,119 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import FilterBar from '../components/FilterBar';
+import StatusBadge from '../components/StatusBadge';
+import { MOCK_EVENTS } from '../mock';
+import type { FilterState, CandidateEvent } from '../types';
+import styles from './ReviewListPage.module.css';
+
+const DEFAULT_FILTERS: FilterState = {
+  ppeType: 'all',
+  status: 'all',
+  zone: [],
+  dateFrom: '',
+  dateTo: '',
+  minConfidence: 0,
+};
+
+// pending events always appear first, then sort by timestamp descending
+function sortEvents(events: CandidateEvent[]): CandidateEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.event_status === 'pending' && b.event_status !== 'pending') return -1;
+    if (a.event_status !== 'pending' && b.event_status === 'pending') return 1;
+    return new Date(b.timestamp_start).getTime() - new Date(a.timestamp_start).getTime();
+  });
+}
+
+function applyFilters(events: CandidateEvent[], f: FilterState): CandidateEvent[] {
+  return events.filter((e) => {
+    if (f.ppeType !== 'all' && e.ppe_type !== f.ppeType) return false;
+    if (f.status !== 'all' && e.event_status !== f.status) return false;
+    if (f.zone.length > 0 && !f.zone.includes(e.zone_name)) return false;
+    if (f.dateFrom && e.timestamp_start < f.dateFrom) return false;
+    if (f.dateTo && e.timestamp_start > f.dateTo + 'T23:59:59') return false;
+    if (e.ai_confidence * 100 < f.minConfidence) return false;
+    return true;
+  });
+}
+
 export default function ReviewListPage() {
-  return <div>후보 이벤트 목록</div>;
+  const navigate = useNavigate();
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+
+  const visibleEvents = useMemo(() => sortEvents(applyFilters(MOCK_EVENTS, filters)), [filters]);
+  const pendingCount = MOCK_EVENTS.filter((e) => e.event_status === 'pending').length;
+
+  return (
+    <div className={styles.page}>
+      {pendingCount > 0 && (
+        <div className={styles.pendingBanner}>
+          미검토 이벤트가 <strong>{pendingCount}건</strong> 있습니다. 확인 후 검토해 주세요.
+        </div>
+      )}
+
+      <FilterBar filters={filters} onChange={setFilters} />
+
+      <div className={styles.tableWrapper}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>이벤트 ID</th>
+              <th>발생 일시</th>
+              <th>구역</th>
+              <th>PPE 유형</th>
+              <th>지속시간</th>
+              <th>신뢰도</th>
+              <th>상태</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleEvents.length === 0 ? (
+              <tr>
+                <td colSpan={7} className={styles.empty}>
+                  조건에 맞는 이벤트가 없습니다.
+                </td>
+              </tr>
+            ) : (
+              visibleEvents.map((event) => (
+                <tr
+                  key={event.event_id}
+                  className={`${styles.row} ${event.event_status === 'pending' ? styles.pendingRow : ''}`}
+                  onClick={() => navigate(`/review/${event.event_id}`)}
+                >
+                  <td className={styles.eventId}>{event.event_id}</td>
+                  <td>{new Date(event.timestamp_start).toLocaleString('ko-KR')}</td>
+                  <td>{event.zone_name}</td>
+                  <td>
+                    <span className={`${styles.ppeTag} ${styles[event.ppe_type]}`}>
+                      {event.ppe_type === 'helmet' ? '안전모' : '안전조끼'}
+                    </span>
+                  </td>
+                  <td>{event.duration_sec}초</td>
+                  <td>
+                    <span
+                      className={`${styles.confidence} ${
+                        event.ai_confidence >= 0.85
+                          ? styles.high
+                          : event.ai_confidence >= 0.7
+                            ? styles.mid
+                            : styles.low
+                      }`}
+                    >
+                      {(event.ai_confidence * 100).toFixed(0)}%
+                    </span>
+                  </td>
+                  <td>
+                    <StatusBadge status={event.event_status} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p className={styles.count}>
+        {visibleEvents.length}건 표시 중 (전체 {MOCK_EVENTS.length}건)
+      </p>
+    </div>
+  );
 }


### PR DESCRIPTION
## 변경 내용

### 새로 구현된 화면
- **HomePage** (`/`): SummaryCard × 4, 미검토 이벤트 테이블, PPE 유형별 바, 구역별 랭킹
- **ReviewListPage** (`/review`): FilterBar 연결 + 클라이언트 필터, pending 항목 우선 정렬 (노란 좌측 보더)
- **ReviewDetailPage** (`/review/:event_id`): 좌우 2열 레이아웃, 검토 버튼 3개, 사유 드롭다운, 다음 이벤트 이동

### 상세
- 미검토 이벤트 자동 상단 정렬
- 확정/오탐/보류 선택에 따라 `review_reason_code` 드롭다운 동적 변경
- 제출 후 ✅ 확인 카드 + "다음 이벤트 →" 연속 검토 워크플로우
- 전체 Mock 데이터 기반 (API 연동 준비 완료)
- CSS Modules 스타일, 빌드 통과 확인 ✅

Resolves #12