### PR TITLE
Update review flow for false positive events

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -148,6 +148,20 @@ POST /api/events/EVT_0001/review
 
 ---
 
+## 검토 결과 처리 기준
+
+`POST /api/events/{event_id}/review` API는 담당자 검토 결과에 따라 후보 이벤트를 다르게 처리함.
+
+| review_result | 처리 방식 |
+|---|---|
+| `confirmed` | 확정 위반으로 처리하고 `candidate_event.event_status`를 `confirmed`로 갱신함 |
+| `hold` | 판단 보류 상태로 처리하고 `candidate_event.event_status`를 `hold`로 갱신함 |
+| `false_positive` | 오탐으로 판단하여 후보 이벤트를 삭제함 |
+
+오탐으로 판단된 이벤트는 장기 보관하지 않으며, 추후 필요한 경우 비식별 집계 수준의 오탐 수만 모델 개선 지표로 활용할 수 있음.
+
+---
+
 ## review_result 값 기준
 
 | 값 | 의미 |

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -138,11 +138,21 @@ def create_event_review(event_id: str, request: ReviewRequest) -> dict:
 
     insert_event_review(review)
 
-    updated_event = get_candidate_event_by_id(event_id)
     saved_review = get_review_by_event_id(event_id)
+
+    if request.review_result == "false_positive":
+        return {
+            "status": "ok",
+            "message": "False positive event deleted",
+            "event_id": event_id,
+            "review_result": request.review_result,
+        }
+
+    updated_event = get_candidate_event_by_id(event_id)
 
     return {
         "status": "ok",
+        "message": "Review saved successfully",
         "event": updated_event,
         "review": saved_review,
     }

--- a/backend/db/event_repository.py
+++ b/backend/db/event_repository.py
@@ -249,6 +249,22 @@ def insert_candidate_event(event: dict[str, Any]) -> None:
         conn.execute(query, event)
         conn.commit()
 
+def delete_candidate_event(event_id: str) -> None:
+    """
+    event_id를 기준으로 후보 이벤트를 삭제함.
+
+    Args:
+        event_id (str):
+            삭제할 후보 이벤트 ID.
+    """
+    query = """
+        DELETE FROM candidate_event
+        WHERE event_id = ?;
+    """
+
+    with get_connection() as conn:
+        conn.execute(query, (event_id,))
+        conn.commit()
 
 def insert_event_review(review: dict[str, Any]) -> None:
     """
@@ -324,13 +340,24 @@ def insert_event_review(review: dict[str, Any]) -> None:
 
     with get_connection() as conn:
         conn.execute(review_query, review)
-        conn.execute(
-            status_query,
-            {
-                "event_status": review["review_result"],
-                "event_id": review["event_id"],
-            },
-        )
+
+        if review["review_result"] == "false_positive":
+            conn.execute(
+                """
+                DELETE FROM candidate_event
+                WHERE event_id = ?;
+                """,
+                (review["event_id"],),
+            )
+        else:
+            conn.execute(
+                status_query,
+                {
+                    "event_status": review["review_result"],
+                    "event_id": review["event_id"],
+                },
+            )
+
         conn.commit()
 
 

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -37,5 +37,5 @@ CREATE TABLE IF NOT EXISTS event_review (
     review_comment TEXT,
     confirmed_violation INTEGER,
     second_review_needed INTEGER,
-    FOREIGN KEY (event_id) REFERENCES candidate_event(event_id)
+    FOREIGN KEY (event_id) REFERENCES candidate_event(event_id) ON DELETE CASCADE
 );


### PR DESCRIPTION
Closes #32

## 작업 범위

담당자 검토 결과 처리 흐름을 새 운영 기준에 맞게 수정한 작업임.

기존에는 `review_result` 값을 그대로 `candidate_event.event_status`에 반영하는 구조였으나, 오탐 이벤트는 장기 보관하지 않고 삭제 처리하는 방향으로 수정함.

---

## 작업 내용

- `POST /api/events/{event_id}/review` 처리 흐름 수정
- `review_result = confirmed`인 경우 `candidate_event.event_status`를 `confirmed`로 갱신
- `review_result = hold`인 경우 `candidate_event.event_status`를 `hold`로 갱신
- `review_result = false_positive`인 경우 후보 이벤트 삭제 처리
- `false_positive`가 `candidate_event.event_status`의 최종 보관 상태값으로 남지 않도록 수정
- 오탐 이벤트 삭제 시 연결된 review 기록도 함께 정리되도록 처리
- API 응답 메시지 정리
- API README에 검토 결과 처리 기준 추가

---

## 테스트

Swagger 문서에서 아래 흐름 확인함.

### confirmed 처리

```text
POST /api/events/EVT_0001/review
```

확인 결과:

```text
GET /api/events/EVT_0001
→ event_status = confirmed
```

### hold 처리

```text
POST /api/events/EVT_0002/review
```

확인 결과:

```text
GET /api/events/EVT_0002
→ event_status = hold
```

### false_positive 처리

```text
POST /api/events/EVT_0003/review
```

확인 결과:

```text
GET /api/events/EVT_0003
→ 404 Event not found
```

전체 목록에서도 `EVT_0003`이 삭제된 것 확인함.

---

## 참고 사항

이번 작업은 문서에서 정리한 운영 기준 중 `오탐 이벤트 삭제 처리`를 API 흐름에 반영한 작업임.

확정 위반 이벤트의 원본 이미지·영상 삭제 및 비식별 데이터 저장 로직은 현재 실제 미디어 저장 구조가 없으므로, 추후 미디어 저장 기능 구현 시 별도 이슈로 확장 예정임.