### PR TITLE
[FEAT] Add warning broadcast settings page (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ data/raw/
 *.pt
 *.onnx
 *.pth
+
+.env

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ReviewListPage from './pages/ReviewListPage';
 import ReviewDetailPage from './pages/ReviewDetailPage';
 import StatsPage from './pages/StatsPage';
 import RecommendPage from './pages/RecommendPage';
+import BroadcastPage from './pages/BroadcastPage';
 
 export default function App() {
   return (
@@ -16,6 +17,7 @@ export default function App() {
           <Route path="review/:event_id" element={<ReviewDetailPage />} />
           <Route path="stats" element={<StatsPage />} />
           <Route path="recommend" element={<RecommendPage />} />
+          <Route path="broadcast" element={<BroadcastPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/broadcast.ts
+++ b/frontend/src/api/broadcast.ts
@@ -1,0 +1,14 @@
+import { apiFetch } from './client';
+import type { BroadcastSettings } from '../types';
+
+export function fetchBroadcastSettings(): Promise<BroadcastSettings> {
+  return apiFetch<BroadcastSettings>('/api/broadcast/settings');
+}
+
+export function saveBroadcastSettings(settings: BroadcastSettings): Promise<BroadcastSettings> {
+  return apiFetch<BroadcastSettings>('/api/broadcast/settings', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
   { to: '/review', label: '검토' },
   { to: '/stats', label: '통계' },
   { to: '/recommend', label: '교육 추천' },
+  { to: '/broadcast', label: '경고 방송' },
 ];
 
 export default function Sidebar() {

--- a/frontend/src/pages/BroadcastPage.module.css
+++ b/frontend/src/pages/BroadcastPage.module.css
@@ -1,0 +1,286 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a202c;
+}
+
+.desc {
+  margin: 0;
+  font-size: 13px;
+  color: #718096;
+}
+
+/* ─── Status messages ─────────────────────────────── */
+.errorMsg {
+  margin: 0;
+  font-size: 13px;
+  color: #c53030;
+  background: #fff5f5;
+  border: 1px solid #fed7d7;
+  border-radius: 6px;
+  padding: 10px 14px;
+}
+
+.successMsg {
+  margin: 0;
+  font-size: 13px;
+  color: #276749;
+  background: #f0fff4;
+  border: 1px solid #c6f6d5;
+  border-radius: 6px;
+  padding: 10px 14px;
+}
+
+/* ─── Sections ────────────────────────────────────── */
+.section {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.sectionDesc {
+  margin: 0;
+  font-size: 12px;
+  color: #a0aec0;
+}
+
+/* ─── Global settings fields ──────────────────────── */
+.fieldRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.fieldLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: #2d3748;
+  width: 200px;
+  flex-shrink: 0;
+}
+
+.fieldHint {
+  font-size: 12px;
+  color: #a0aec0;
+}
+
+.fieldInline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.unit {
+  font-size: 13px;
+  color: #4a5568;
+}
+
+/* ─── Toggle button ───────────────────────────────── */
+.toggleBtn {
+  font-size: 13px;
+  font-weight: 700;
+  padding: 5px 18px;
+  border-radius: 20px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+  min-width: 60px;
+}
+
+.toggleOn {
+  background: #3182ce;
+  color: #fff;
+}
+
+.toggleOff {
+  background: #e2e8f0;
+  color: #718096;
+}
+
+/* ─── Generic inputs ──────────────────────────────── */
+.select {
+  font-size: 13px;
+  padding: 5px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  color: #2d3748;
+  cursor: pointer;
+}
+
+.select:focus {
+  outline: none;
+  border-color: #3182ce;
+}
+
+.numberInput {
+  font-size: 13px;
+  padding: 5px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  width: 80px;
+  color: #2d3748;
+}
+
+.numberInput:focus {
+  outline: none;
+  border-color: #3182ce;
+}
+
+.textInput {
+  font-size: 13px;
+  padding: 5px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #2d3748;
+  min-width: 200px;
+}
+
+.textInput:focus {
+  outline: none;
+  border-color: #3182ce;
+}
+
+/* ─── Template list ───────────────────────────────── */
+.addBtn {
+  font-size: 13px;
+  padding: 5px 14px;
+  border: 1px solid #3182ce;
+  border-radius: 6px;
+  background: #fff;
+  color: #3182ce;
+  cursor: pointer;
+}
+
+.addBtn:hover {
+  background: #3182ce;
+  color: #fff;
+}
+
+.templateList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.templateCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #f7fafc;
+}
+
+.templateMeta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.metaField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metaLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: #718096;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.removeBtn {
+  margin-left: auto;
+  font-size: 12px;
+  color: #e53e3e;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  align-self: flex-start;
+}
+
+.removeBtn:hover {
+  background: #fff5f5;
+}
+
+.messageInput {
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  resize: vertical;
+  color: #2d3748;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.messageInput:focus {
+  outline: none;
+  border-color: #3182ce;
+}
+
+/* ─── Footer ──────────────────────────────────────── */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.saveBtn {
+  font-size: 14px;
+  font-weight: 600;
+  padding: 9px 28px;
+  border: none;
+  border-radius: 6px;
+  background: #3182ce;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.saveBtn:hover:not(:disabled) {
+  background: #2b6cb0;
+}
+
+.saveBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/BroadcastPage.tsx
+++ b/frontend/src/pages/BroadcastPage.tsx
@@ -1,0 +1,254 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchBroadcastSettings, saveBroadcastSettings } from '../api/broadcast';
+import type { BroadcastSettings, BroadcastTemplate, BroadcastLanguage } from '../types';
+import styles from './BroadcastPage.module.css';
+
+// Default template when user adds a new row
+const BLANK_TEMPLATE: BroadcastTemplate = {
+  ppe_type: 'helmet',
+  zone_name: '',
+  language: 'ko',
+  message: '',
+};
+
+// Fallback defaults used when the backend has no settings yet
+const DEFAULT_SETTINGS: BroadcastSettings = {
+  enabled: false,
+  default_language: 'ko',
+  cooldown_sec: 30,
+  templates: [
+    {
+      ppe_type: 'helmet',
+      zone_name: '',
+      language: 'ko',
+      message: '해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.',
+    },
+    {
+      ppe_type: 'vest',
+      zone_name: '',
+      language: 'ko',
+      message: '해당 작업 구역의 작업자는 안전조끼 착용 상태를 확인해 주세요.',
+    },
+  ],
+};
+
+const PPE_LABEL: Record<string, string> = { helmet: '안전모', vest: '안전조끼' };
+const LANG_LABEL: Record<BroadcastLanguage, string> = { ko: '한국어', en: 'English' };
+
+export default function BroadcastPage() {
+  const [settings, setSettings] = useState<BroadcastSettings>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchBroadcastSettings()
+      .then(setSettings)
+      .catch(() => {
+        // Backend API not yet implemented — fall back to default settings
+        setSettings(DEFAULT_SETTINGS);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = useCallback(() => {
+    setSaving(true);
+    setError(null);
+    saveBroadcastSettings(settings)
+      .then(setSettings)
+      .catch(() => {
+        // Show a warning but keep edits so the user doesn't lose work
+        setError('저장 실패: 백엔드 API가 아직 구현 중입니다. 설정은 로컬에서만 유지됩니다.');
+      })
+      .finally(() => {
+        setSaving(false);
+        setSuccessMsg('설정이 저장되었습니다.');
+        setTimeout(() => setSuccessMsg(null), 3000);
+      });
+  }, [settings]);
+
+  function updateField<K extends keyof BroadcastSettings>(key: K, value: BroadcastSettings[K]) {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function updateTemplate(index: number, patch: Partial<BroadcastTemplate>) {
+    setSettings((prev) => {
+      const templates = prev.templates.map((t, i) => (i === index ? { ...t, ...patch } : t));
+      return { ...prev, templates };
+    });
+  }
+
+  function addTemplate() {
+    setSettings((prev) => ({ ...prev, templates: [...prev.templates, { ...BLANK_TEMPLATE }] }));
+  }
+
+  function removeTemplate(index: number) {
+    setSettings((prev) => ({
+      ...prev,
+      templates: prev.templates.filter((_, i) => i !== index),
+    }));
+  }
+
+  if (loading) {
+    return <p style={{ color: '#718096' }}>설정을 불러오는 중...</p>;
+  }
+
+  return (
+    <div className={styles.page}>
+      {/* Page header */}
+      <div className={styles.header}>
+        <h2 className={styles.title}>경고 방송 설정</h2>
+        <p className={styles.desc}>
+          PPE 미착용이 감지될 때 현장 작업자에게 전송할 방송을 제어합니다. 실제 음성
+          출력은 별도 기능에서 처리됩니다.
+        </p>
+      </div>
+
+      {error && <p className={styles.errorMsg}>⚠ {error}</p>}
+      {successMsg && <p className={styles.successMsg}>✓ {successMsg}</p>}
+
+      {/* ─── Global settings ─────────────────────────────────── */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>전체 설정</h3>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.fieldLabel}>경고 방송 사용</label>
+          <button
+            className={`${styles.toggleBtn} ${settings.enabled ? styles.toggleOn : styles.toggleOff}`}
+            onClick={() => updateField('enabled', !settings.enabled)}
+            aria-pressed={settings.enabled}
+          >
+            {settings.enabled ? 'ON' : 'OFF'}
+          </button>
+          <span className={styles.fieldHint}>
+            {settings.enabled ? '방송이 활성화되어 있습니다.' : '방송이 비활성화되어 있습니다.'}
+          </span>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.fieldLabel}>기본 방송 언어</label>
+          <select
+            className={styles.select}
+            value={settings.default_language}
+            onChange={(e) => updateField('default_language', e.target.value as BroadcastLanguage)}
+          >
+            <option value="ko">한국어</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.fieldLabel}>중복 방송 방지 (cooldown)</label>
+          <div className={styles.fieldInline}>
+            <input
+              type="number"
+              className={styles.numberInput}
+              min={0}
+              max={3600}
+              value={settings.cooldown_sec}
+              onChange={(e) => updateField('cooldown_sec', Number(e.target.value))}
+            />
+            <span className={styles.unit}>초</span>
+          </div>
+          <span className={styles.fieldHint}>동일 상황에 대해 재방송까지 대기 시간</span>
+        </div>
+      </section>
+
+      {/* ─── Message templates ───────────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h3 className={styles.sectionTitle}>PPE 유형별 메시지 템플릿</h3>
+          <button className={styles.addBtn} onClick={addTemplate}>
+            + 템플릿 추가
+          </button>
+        </div>
+        <p className={styles.sectionDesc}>
+          구역명을 비워두면 모든 구역에 적용됩니다. 구역명을 입력하면 해당 구역에서만
+          사용됩니다.
+        </p>
+
+        {settings.templates.length === 0 && (
+          <p style={{ color: '#718096', fontSize: 13 }}>등록된 템플릿이 없습니다.</p>
+        )}
+
+        <div className={styles.templateList}>
+          {settings.templates.map((tpl, idx) => (
+            <div key={idx} className={styles.templateCard}>
+              <div className={styles.templateMeta}>
+                {/* PPE type */}
+                <div className={styles.metaField}>
+                  <span className={styles.metaLabel}>PPE 유형</span>
+                  <select
+                    className={styles.select}
+                    value={tpl.ppe_type}
+                    onChange={(e) =>
+                      updateTemplate(idx, { ppe_type: e.target.value as 'helmet' | 'vest' })
+                    }
+                  >
+                    <option value="helmet">{PPE_LABEL.helmet}</option>
+                    <option value="vest">{PPE_LABEL.vest}</option>
+                  </select>
+                </div>
+
+                {/* Zone */}
+                <div className={styles.metaField}>
+                  <span className={styles.metaLabel}>구역명 (선택)</span>
+                  <input
+                    type="text"
+                    className={styles.textInput}
+                    placeholder="예: 프레스 구역 (비우면 전체)"
+                    value={tpl.zone_name}
+                    onChange={(e) => updateTemplate(idx, { zone_name: e.target.value })}
+                  />
+                </div>
+
+                {/* Language */}
+                <div className={styles.metaField}>
+                  <span className={styles.metaLabel}>언어</span>
+                  <select
+                    className={styles.select}
+                    value={tpl.language}
+                    onChange={(e) =>
+                      updateTemplate(idx, { language: e.target.value as BroadcastLanguage })
+                    }
+                  >
+                    {(Object.keys(LANG_LABEL) as BroadcastLanguage[]).map((lang) => (
+                      <option key={lang} value={lang}>
+                        {LANG_LABEL[lang]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  className={styles.removeBtn}
+                  onClick={() => removeTemplate(idx)}
+                  title="삭제"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* Message textarea */}
+              <textarea
+                className={styles.messageInput}
+                rows={2}
+                placeholder="방송할 메시지를 입력하세요."
+                value={tpl.message}
+                onChange={(e) => updateTemplate(idx, { message: e.target.value })}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Save button */}
+      <div className={styles.footer}>
+        <button className={styles.saveBtn} onClick={handleSave} disabled={saving}>
+          {saving ? '저장 중…' : '설정 저장'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -120,3 +120,23 @@ export interface FilterState {
   dateTo: string;
   minConfidence: number;
 }
+
+// --- Warning Broadcast Settings ---
+
+export type BroadcastLanguage = 'ko' | 'en';
+
+// Per-PPE-type message template with optional zone override
+export interface BroadcastTemplate {
+  ppe_type: Exclude<PpeType, 'all'>;
+  zone_name: string; // empty string means "all zones"
+  language: BroadcastLanguage;
+  message: string;
+}
+
+// Top-level broadcast control settings saved/loaded via API
+export interface BroadcastSettings {
+  enabled: boolean;
+  default_language: BroadcastLanguage;
+  cooldown_sec: number;
+  templates: BroadcastTemplate[];
+}


### PR DESCRIPTION
## 개요

Issue #48 `[Feature] Add warning broadcast control settings` 구현 — 경고 방송 제어 설정 UI 및 API 연동 기반 구축.

Resolves #48

> ⚠ 이 PR은 실제 음성 출력 기능이 **아닙니다.** 방송 ON/OFF, 언어, 메시지 템플릿, cooldown 등 설정 기반을 프론트엔드에서 관리할 수 있도록 UI를 구현한 것입니다.

---

## 변경 내용

### 신규 파일

| 파일 | 내용 |
|---|---|
| `frontend/src/pages/BroadcastPage.tsx` | 경고 방송 설정 페이지 컴포넌트 |
| `frontend/src/pages/BroadcastPage.module.css` | 설정 페이지 스타일 |
| `frontend/src/api/broadcast.ts` | `fetchBroadcastSettings` / `saveBroadcastSettings` API 함수 |

### 수정 파일

| 파일 | 내용 |
|---|---|
| `frontend/src/types/index.ts` | `BroadcastLanguage`, `BroadcastTemplate`, `BroadcastSettings` 타입 추가 |
| `frontend/src/App.tsx` | `/broadcast` 라우트 등록 |
| `frontend/src/components/Sidebar.tsx` | 사이드바에 "경고 방송" 메뉴 항목 추가 |

---

## 구현된 설정 항목

| 설정 | 설명 |
|---|---|
| **경고 방송 사용 ON/OFF** | 토글 버튼으로 전체 방송 활성화/비활성화 |
| **기본 방송 언어** | 한국어 / English 선택 |
| **중복 방송 방지 cooldown** | 초 단위 숫자 입력 (동일 상황 재방송 대기 시간) |
| **PPE 유형별 메시지 템플릿** | 안전모·안전조끼 × 구역(전체 또는 특정 구역) × 언어 × 메시지 |

---

## 주요 동작

- **API 연동 graceful fallback** — 백엔드 `/api/broadcast/settings`가 아직 미구현인 경우, 기본값으로 폴백하여 UI가 바로 사용 가능
- **저장 실패 시 편집 내용 유지** — API 저장 실패 시 에러 메시지만 표시하고 입력 내용은 보존
- **템플릿 동적 추가/삭제** — "+ 템플릿 추가" 버튼으로 행 추가, ✕ 버튼으로 삭제
- **저장 완료 메시지** — 저장 후 3초 동안 성공 메시지 표시

---

## 백엔드 연동 필요 사항 (robinjh 확인 필요)

이 PR에서 호출하는 API 엔드포인트가 아직 존재하지 않습니다. 아래 스펙에 맞게 구현이 필요합니다:

```
GET  /api/broadcast/settings
     → BroadcastSettings JSON 반환

PUT  /api/broadcast/settings
     body: BroadcastSettings JSON
     → 저장 후 BroadcastSettings JSON 반환
```

**BroadcastSettings 스키마:**
```json
{
  "enabled": true,
  "default_language": "ko",
  "cooldown_sec": 30,
  "templates": [
    {
      "ppe_type": "helmet",
      "zone_name": "",
      "language": "ko",
      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
    }
  ]
}
```

---

## 테스트 방법

```bash
cd frontend
npm run dev  # http://localhost:5173
```

1. 사이드바에서 **"경고 방송"** 클릭 → `/broadcast` 페이지 진입
2. **경고 방송 사용** 토글 ON/OFF 확인
3. **기본 방송 언어** 변경 확인
4. **cooldown** 숫자 변경 확인
5. **+ 템플릿 추가** 클릭 → 새 행 추가 확인
6. 각 템플릿 PPE 유형·구역·언어·메시지 편집 확인
7. ✕ 버튼으로 템플릿 삭제 확인
8. **설정 저장** 클릭 → 백엔드 없을 경우 경고 메시지 표시 + 편집 내용 유지 확인

---

## 관련 이슈

- Resolves #48
- 실제 방송 실행 로직은 #49에서 별도 구현 예정
