### PR TITLE
Add broadcast settings API

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -326,6 +326,78 @@ GET /api/recommendations?quarter=2026-Q2
 
 ---
 
+## 경고 방송 설정 API
+
+### `GET /api/broadcast/settings`
+
+경고 방송 설정을 조회함.
+
+예시:
+
+```http
+GET /api/broadcast/settings
+```
+
+응답 예시:
+
+```json
+{
+  "enabled": true,
+  "default_language": "ko",
+  "cooldown_sec": 30,
+  "templates": [
+    {
+      "ppe_type": "helmet",
+      "zone_name": "",
+      "language": "ko",
+      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
+    }
+  ]
+}
+```
+
+---
+
+### `PUT /api/broadcast/settings`
+
+경고 방송 설정을 저장함.
+
+예시:
+
+```http
+PUT /api/broadcast/settings
+```
+
+요청 Body 예시:
+
+```json
+{
+  "enabled": true,
+  "default_language": "ko",
+  "cooldown_sec": 30,
+  "templates": [
+    {
+      "ppe_type": "helmet",
+      "zone_name": "",
+      "language": "ko",
+      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
+    }
+  ]
+}
+```
+
+응답은 저장된 설정을 다시 반환함.
+
+---
+
+## 참고 사항
+
+이 API는 경고 방송 설정을 저장하고 조회하기 위한 API임.
+
+실제 경고 방송 실행, 터미널 출력, TTS 음성 출력은 별도 기능에서 구현함.
+
+---
+
 ## 주의 사항
 
 - 같은 이벤트에 대해 검토 결과를 두 번 저장하면 `409 Review already exists` 응답 반환.

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -22,6 +22,8 @@ from backend.db.event_repository import (
     get_education_recommendations,
     generate_quarterly_stats,
     generate_education_recommendations,
+    get_broadcast_settings,
+    save_broadcast_settings,
 )
 
 
@@ -55,6 +57,31 @@ class ReviewRequest(BaseModel):
     review_reason_code: str = Field(..., example="confirmed_no_helmet")
     review_comment: str = Field(default="", example="실제 안전모 미착용")
     second_review_needed: bool = Field(default=False, example=False)
+
+
+class BroadcastTemplate(BaseModel):
+    """
+    경고 방송 메시지 템플릿.
+    """
+
+    ppe_type: str = Field(..., example="helmet")
+    zone_name: str = Field(default="", example="프레스 구역")
+    language: str = Field(..., example="ko")
+    message: str = Field(
+        ...,
+        example="해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.",
+    )
+
+
+class BroadcastSettingsRequest(BaseModel):
+    """
+    경고 방송 설정 저장 요청 모델.
+    """
+
+    enabled: bool = Field(default=True, example=True)
+    default_language: str = Field(default="ko", example="ko")
+    cooldown_sec: int = Field(default=30, example=30)
+    templates: list[BroadcastTemplate] = Field(default_factory=list)
 
 
 @app.get("/")
@@ -259,3 +286,31 @@ def create_education_recommendations(quarter: str = "2026-Q2") -> dict:
         )
 
     return recommendations
+
+
+@app.get("/api/broadcast/settings")
+def read_broadcast_settings() -> dict:
+    """
+    경고 방송 설정 조회.
+
+    Returns:
+        dict:
+            경고 방송 사용 여부, 기본 언어, cooldown, 메시지 템플릿 목록.
+    """
+    return get_broadcast_settings()
+
+
+@app.put("/api/broadcast/settings")
+def update_broadcast_settings(request: BroadcastSettingsRequest) -> dict:
+    """
+    경고 방송 설정 저장.
+
+    Args:
+        request (BroadcastSettingsRequest):
+            경고 방송 설정 요청 데이터.
+
+    Returns:
+        dict:
+            저장된 경고 방송 설정.
+    """
+    return save_broadcast_settings(request.model_dump())

--- a/backend/db/check_db.py
+++ b/backend/db/check_db.py
@@ -137,6 +137,36 @@ def check_database() -> None:
         false_positive_aggregate = cursor.fetchall()
         print_rows("false_positive_aggregate", false_positive_aggregate)
 
+        cursor.execute(
+            """
+            SELECT
+                setting_id,
+                enabled,
+                default_language,
+                cooldown_sec,
+                updated_at
+            FROM broadcast_setting;
+            """
+        )
+        broadcast_setting = cursor.fetchall()
+        print_rows("broadcast_setting", broadcast_setting)
+
+        cursor.execute(
+            """
+            SELECT
+                template_id,
+                setting_id,
+                ppe_type,
+                zone_name,
+                language,
+                message
+            FROM broadcast_message_template
+            ORDER BY template_id;
+            """
+        )
+        broadcast_templates = cursor.fetchall()
+        print_rows("broadcast_message_template", broadcast_templates)
+
     finally:
         conn.close()
 

--- a/backend/db/event_repository.py
+++ b/backend/db/event_repository.py
@@ -1077,3 +1077,127 @@ def generate_education_recommendations(quarter: str) -> dict:
         conn.commit()
 
     return get_education_recommendations(quarter)
+
+def get_broadcast_settings() -> dict[str, Any]:
+    """
+    경고 방송 설정을 조회함.
+
+    Returns:
+        dict[str, Any]:
+            경고 방송 사용 여부, 기본 언어, cooldown, 메시지 템플릿 목록.
+    """
+    with get_connection() as conn:
+        setting = conn.execute(
+            """
+            SELECT
+                setting_id,
+                enabled,
+                default_language,
+                cooldown_sec
+            FROM broadcast_setting
+            WHERE setting_id = 'DEFAULT';
+            """
+        ).fetchone()
+
+        if setting is None:
+            return {
+                "enabled": True,
+                "default_language": "ko",
+                "cooldown_sec": 30,
+                "templates": [],
+            }
+
+        templates = conn.execute(
+            """
+            SELECT
+                ppe_type,
+                zone_name,
+                language,
+                message
+            FROM broadcast_message_template
+            WHERE setting_id = ?
+            ORDER BY ppe_type ASC, zone_name ASC, template_id ASC;
+            """,
+            (setting["setting_id"],),
+        ).fetchall()
+
+    return {
+        "enabled": bool(setting["enabled"]),
+        "default_language": setting["default_language"],
+        "cooldown_sec": setting["cooldown_sec"],
+        "templates": [dict(row) for row in templates],
+    }
+
+
+def save_broadcast_settings(settings: dict[str, Any]) -> dict[str, Any]:
+    """
+    경고 방송 설정을 저장함.
+
+    Args:
+        settings (dict[str, Any]):
+            프론트엔드에서 전달한 경고 방송 설정.
+
+    Returns:
+        dict[str, Any]:
+            저장 후 다시 조회한 경고 방송 설정.
+    """
+    updated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    templates = settings.get("templates", [])
+
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO broadcast_setting (
+                setting_id,
+                enabled,
+                default_language,
+                cooldown_sec,
+                updated_at
+            )
+            VALUES ('DEFAULT', ?, ?, ?, ?)
+            ON CONFLICT(setting_id) DO UPDATE SET
+                enabled = excluded.enabled,
+                default_language = excluded.default_language,
+                cooldown_sec = excluded.cooldown_sec,
+                updated_at = excluded.updated_at;
+            """,
+            (
+                1 if settings.get("enabled", True) else 0,
+                settings.get("default_language", "ko"),
+                settings.get("cooldown_sec", 30),
+                updated_at,
+            ),
+        )
+
+        conn.execute(
+            """
+            DELETE FROM broadcast_message_template
+            WHERE setting_id = 'DEFAULT';
+            """
+        )
+
+        for index, template in enumerate(templates, start=1):
+            conn.execute(
+                """
+                INSERT INTO broadcast_message_template (
+                    template_id,
+                    setting_id,
+                    ppe_type,
+                    zone_name,
+                    language,
+                    message
+                )
+                VALUES (?, 'DEFAULT', ?, ?, ?, ?);
+                """,
+                (
+                    f"BCAST_TEMPLATE_{index:03d}",
+                    template["ppe_type"],
+                    template.get("zone_name", ""),
+                    template["language"],
+                    template["message"],
+                ),
+            )
+
+        conn.commit()
+
+    return get_broadcast_settings()

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -108,3 +108,23 @@ CREATE TABLE IF NOT EXISTS false_positive_aggregate (
     false_positive_count INTEGER NOT NULL DEFAULT 0,
     updated_at TEXT NOT NULL
 );
+
+-- 경고 방송 기본 설정
+CREATE TABLE IF NOT EXISTS broadcast_setting (
+    setting_id TEXT PRIMARY KEY,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    default_language TEXT NOT NULL DEFAULT 'ko',
+    cooldown_sec INTEGER NOT NULL DEFAULT 30,
+    updated_at TEXT NOT NULL
+);
+
+-- PPE 유형/구역/언어별 경고 방송 메시지 템플릿
+CREATE TABLE IF NOT EXISTS broadcast_message_template (
+    template_id TEXT PRIMARY KEY,
+    setting_id TEXT NOT NULL,
+    ppe_type TEXT NOT NULL,
+    zone_name TEXT NOT NULL DEFAULT '',
+    language TEXT NOT NULL,
+    message TEXT NOT NULL,
+    FOREIGN KEY (setting_id) REFERENCES broadcast_setting(setting_id) ON DELETE CASCADE
+);

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -206,3 +206,60 @@ INSERT OR IGNORE INTO education_recommendation (
     0.8,
     '2026-06-30 18:00:00'
 );
+
+-- 경고 방송 기본 설정
+INSERT OR IGNORE INTO broadcast_setting (
+    setting_id,
+    enabled,
+    default_language,
+    cooldown_sec,
+    updated_at
+) VALUES (
+    'DEFAULT',
+    1,
+    'ko',
+    30,
+    '2026-05-19 00:00:00'
+);
+
+-- 경고 방송 메시지 기본 템플릿
+INSERT OR IGNORE INTO broadcast_message_template (
+    template_id,
+    setting_id,
+    ppe_type,
+    zone_name,
+    language,
+    message
+) VALUES
+(
+    'BCAST_TEMPLATE_001',
+    'DEFAULT',
+    'helmet',
+    '',
+    'ko',
+    '해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.'
+),
+(
+    'BCAST_TEMPLATE_002',
+    'DEFAULT',
+    'helmet',
+    '',
+    'en',
+    'Workers in this area, please check your helmet.'
+),
+(
+    'BCAST_TEMPLATE_003',
+    'DEFAULT',
+    'vest',
+    '',
+    'ko',
+    '해당 작업 구역의 작업자는 안전조끼 착용 상태를 확인해 주세요.'
+),
+(
+    'BCAST_TEMPLATE_004',
+    'DEFAULT',
+    'vest',
+    '',
+    'en',
+    'Workers in this area, please check your safety vest.'
+);


### PR DESCRIPTION
Resolves #48

## 개요

경고 방송 설정 UI에서 사용할 수 있는 백엔드 API를 추가함.

프론트엔드 `BroadcastPage`에서 호출하는 아래 엔드포인트를 구현하여, 방송 ON/OFF, 기본 언어, cooldown, PPE 유형별 메시지 템플릿을 DB에 저장하고 다시 불러올 수 있도록 구성함.

```http
GET /api/broadcast/settings
PUT /api/broadcast/settings
```

이번 PR은 경고 방송 설정을 저장·조회하기 위한 백엔드 연동 작업이며, 실제 방송 출력이나 TTS 기능은 포함하지 않음.

---

## 작업 내용

### 1. 경고 방송 설정 DB 구조 추가

경고 방송 설정 저장을 위해 아래 테이블을 추가함.

- `broadcast_setting`
  - 방송 사용 여부
  - 기본 방송 언어
  - 중복 방송 방지 cooldown
  - 수정 시각 저장

- `broadcast_message_template`
  - PPE 유형
  - 구역명
  - 언어
  - 경고 방송 메시지 템플릿 저장

---

### 2. 기본 seed 데이터 추가

기본 경고 방송 설정과 helmet/vest 기준 한국어·영어 메시지 템플릿을 추가함.

기본 설정 예시:

```json
{
  "enabled": true,
  "default_language": "ko",
  "cooldown_sec": 30
}
```

기본 메시지 예시:

```text
해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.
Workers in this area, please check your helmet.
```

---

### 3. Repository 함수 추가

`backend/db/event_repository.py`에 경고 방송 설정 조회 및 저장 함수를 추가함.

- `get_broadcast_settings()`
- `save_broadcast_settings(settings)`

처리 방식:

```text
GET 요청
→ broadcast_setting 조회
→ broadcast_message_template 목록 조회
→ 프론트 BroadcastSettings 구조로 반환

PUT 요청
→ broadcast_setting upsert
→ 기존 template 삭제
→ 요청 body의 templates 재저장
→ 저장된 설정 다시 조회 후 반환
```

---

### 4. FastAPI 엔드포인트 추가

`backend/api/main.py`에 경고 방송 설정 API를 추가함.

```http
GET /api/broadcast/settings
PUT /api/broadcast/settings
```

요청/응답 구조는 프론트엔드 `BroadcastSettings` 타입에 맞춤.

```json
{
  "enabled": false,
  "default_language": "en",
  "cooldown_sec": 45,
  "templates": [
    {
      "ppe_type": "helmet",
      "zone_name": "",
      "language": "ko",
      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
    }
  ]
}
```

---

### 5. DB 확인 스크립트 수정

`backend/db/check_db.py`에서 경고 방송 설정 테이블을 확인할 수 있도록 출력 항목을 추가함.

- `broadcast_setting`
- `broadcast_message_template`

---

### 6. API README 수정

`backend/api/README.md`에 경고 방송 설정 API 사용 방법을 추가함.

포함 내용:

- `GET /api/broadcast/settings`
- `PUT /api/broadcast/settings`
- 요청 Body 예시
- 응답 예시
- 실제 방송 출력은 후속 기능에서 처리한다는 참고 사항

---

## 테스트

아래 순서로 테스트함.

```bash
python backend/db/init_db.py
python backend/db/check_db.py
python -m uvicorn backend.api.main:app --reload
```

Swagger에서 다음 API를 확인함.

```http
GET /api/broadcast/settings
PUT /api/broadcast/settings
GET /api/broadcast/settings
```

---

## 테스트 결과

### 1. 기본 설정 조회 확인

`GET /api/broadcast/settings` 호출 시 기본 설정과 기본 메시지 템플릿이 정상 반환됨.

확인 내용:

- `enabled`
- `default_language`
- `cooldown_sec`
- `templates`

---

### 2. 설정 저장 확인

`PUT /api/broadcast/settings`로 아래 값을 저장함.

```json
{
  "enabled": false,
  "default_language": "en",
  "cooldown_sec": 45,
  "templates": [
    {
      "ppe_type": "helmet",
      "zone_name": "",
      "language": "ko",
      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
    },
    {
      "ppe_type": "helmet",
      "zone_name": "",
      "language": "en",
      "message": "Workers in this area, please check your helmet."
    }
  ]
}
```

저장 후 응답에서 변경값이 정상 반영되는 것을 확인함.

---

### 3. 재조회 확인

PUT 이후 다시 `GET /api/broadcast/settings`를 호출하여 저장된 값이 유지되는 것을 확인함.

확인 결과:

- `enabled: false`
- `default_language: "en"`
- `cooldown_sec: 45`
- `templates`가 PUT 요청의 템플릿 목록으로 갱신됨

---

## 참고 사항

- 이번 PR은 경고 방송 설정 저장 및 조회 API 구현 작업임.
- 실제 경고 방송 실행, 터미널 출력, TTS 음성 출력은 후속 이슈에서 별도 구현 예정임.
- 프론트엔드 BroadcastPage에서 호출하는 API 스펙에 맞춰 구현함.