### PR TITLE
Add storage static file mount

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -390,6 +390,26 @@ PUT /api/broadcast/settings
 
 ---
 
+## 정적 미디어 파일 제공
+
+후보 이벤트 검토용 썸네일과 영상 클립은 `storage` 디렉터리 아래에 저장되며, FastAPI에서 `/storage` 경로로 정적 파일을 제공함.
+
+예시 파일 경로:
+
+```text
+storage/candidate_events/thumbnails/EVT_xxxx.jpg
+```
+
+브라우저 접근 URL:
+
+```text
+http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_xxxx.jpg
+```
+
+없는 파일에 접근하면 404를 반환하고, 실제 파일이 존재하면 200으로 파일을 반환함.
+
+이 경로는 프론트엔드 ReviewDetailPage에서 후보 이벤트의 `thumbnail_path`, `video_clip_path`를 표시할 때 사용함.
+
 ## 참고 사항
 
 이 API는 경고 방송 설정을 저장하고 조회하기 위한 API임.

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -8,9 +8,11 @@ PPE 분석 시스템 초기 FastAPI 서버 파일.
 """
 
 from datetime import datetime
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 from backend.db.event_repository import (
@@ -41,6 +43,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Serve generated event media files
+_STORAGE_DIR = Path(__file__).resolve().parents[2] / "storage"
+_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+app.mount(
+    "/storage",
+    StaticFiles(directory=str(_STORAGE_DIR)),
+    name="storage",
+)
 
 class ReviewRequest(BaseModel):
     """


### PR DESCRIPTION
대응 이슈 : issue #56 
## 작업 내용

- FastAPI에 `/storage` 정적 파일 마운트 추가
- 프로젝트 루트의 `storage` 디렉터리를 API 서버에서 접근 가능하도록 처리
- API README에 정적 미디어 파일 접근 방법 추가

---

## 수정 이유

PR #52의 `candidate_event_service`에서 후보 이벤트 썸네일을 아래 경로에 저장하도록 구현되어 있음.

```text
storage/candidate_events/thumbnails/{event_id}.jpg
```

또한 DB의 `thumbnail_path`, `video_clip_path`에는 프로젝트 기준 상대 경로가 저장됨.

하지만 기존 FastAPI 서버에는 `storage` 디렉터리를 정적 파일로 제공하는 라우트가 없어, 프론트엔드에서 해당 경로를 URL로 변환하더라도 썸네일/클립 파일에 접근할 수 없었음.

이번 수정에서는 FastAPI의 `StaticFiles`를 사용해 `/storage` 경로를 프로젝트 루트의 `storage` 디렉터리에 매핑함.

이를 통해 프론트엔드에서 아래 형태의 URL로 후보 이벤트 미디어 파일에 접근할 수 있음.

```text
http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_xxxx.jpg
```

---

## 구현 내용

`backend/api/main.py`에 아래 내용을 추가함.

- `Path` import
- `StaticFiles` import
- `storage` 디렉터리 생성 처리
- `/storage` 정적 파일 마운트

`storage` 디렉터리가 없는 경우에도 서버 실행 시 자동 생성되도록 처리함.

```python
_STORAGE_DIR = Path(__file__).resolve().parents[2] / "storage"
_STORAGE_DIR.mkdir(parents=True, exist_ok=True)

app.mount(
    "/storage",
    StaticFiles(directory=str(_STORAGE_DIR)),
    name="storage",
)
```

---

## 확인 내용

백엔드 서버 실행 후 아래 명령어로 확인함.

```bash
python -m uvicorn backend.api.main:app --reload
```

### 1. 존재하지 않는 파일 요청

```bash
curl.exe -o NUL -w "%{http_code}`n" http://127.0.0.1:8000/storage/candidate_events/thumbnails/nonexistent.jpg
```

결과:

```text
404
```

`404`는 `/storage` 라우트가 정상적으로 잡혔고, 해당 파일만 존재하지 않는다는 의미임.

### 2. 실제 썸네일 파일 요청

```bash
curl.exe -o NUL -w "%{http_code}`n" http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_20260519160059_b95d63.jpg
```

결과:

```text
200
```

실제 파일이 존재하는 경우 `/storage/...` 경로로 정상 접근 가능한 것을 확인함.

---

## 영향 범위

- `backend/api/main.py`
- `backend/api/README.md`

이번 PR은 저장된 후보 이벤트 미디어 파일을 프론트엔드에서 접근할 수 있도록 하는 백엔드 정적 파일 마운트 작업임.
