### PR TITLE
Add warning broadcast execution with TTS output

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+pyttsx3

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -80,3 +80,88 @@ AI 탐지 결과로 생성된 후보 이벤트의 썸네일과 영상 참조 파
 현재 단계에서는 실제 짧은 클립 생성보다, 원본 영상 또는 추론 결과 영상 경로를 `video_clip_path`에 저장하는 구조를 우선 사용한다.
 
 짧은 영상 클립 생성 기능은 이후 `_save_clip()` 함수 등을 추가하여 확장할 수 있다.
+
+---
+
+## Warning Broadcast Service
+
+`warning_broadcast_service.py`는 경고 방송 설정을 기반으로 PPE 미착용 후보 이벤트에 대한 방송 메시지를 선택하고, 1차 단계에서는 터미널 출력 방식으로 방송을 시뮬레이션한다.
+
+주요 기능은 다음과 같다.
+
+- 방송 사용 여부(`enabled`) 확인
+- 기본 언어(`default_language`) 기준 메시지 선택
+- PPE 유형 및 구역별 메시지 템플릿 선택
+- 특정 구역 템플릿이 없을 경우 전체 구역 템플릿 사용
+- cooldown 시간 내 동일 상황의 중복 방송 방지
+- 방송 실행 결과를 dict와 터미널 로그 형태로 반환
+
+## 방송 실행 흐름
+
+```text
+AI 탐지 결과 발생
+→ candidate_event 저장
+→ 저장된 이벤트의 zone_name 조회
+→ 경고 방송 설정 조회
+→ 메시지 선택
+→ cooldown 확인
+→ 터미널 경고 메시지 출력
+```
+
+## 터미널 출력 예시
+
+```text
+[WARNING BROADCAST]
+event_id=EVT_20260526153000_a1b2c3
+result=broadcast_printed
+ppe_type=helmet
+zone_name=프레스 구역
+language=ko
+message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
+executed_at=2026-05-26 15:30:00
+```
+
+cooldown으로 방송이 생략된 경우 다음과 같이 출력된다.
+
+```text
+[WARNING BROADCAST SKIPPED]
+event_id=EVT_20260526153000_a1b2c3
+result=cooldown_active
+ppe_type=helmet
+zone_name=프레스 구역
+language=ko
+message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
+cooldown_remaining_sec=30
+executed_at=2026-05-26 15:30:01
+```
+
+## 수동 테스트 방법
+
+DB 초기화 후 경고 방송 서비스 테스트 스크립트를 실행한다.
+
+```bash
+python backend/db/init_db.py
+python -m backend.services.test_warning_broadcast_service
+```
+
+테스트 항목:
+
+- 후보 이벤트 저장 후 경고 방송 출력 확인
+- PPE 유형 및 구역별 메시지 선택 확인
+- 기본 언어 변경 시 영어 메시지 선택 확인
+- cooldown 시간 내 재방송 생략 확인
+- 방송 비활성화 시 실행 생략 확인
+
+정상 동작 시 다음 메시지를 확인할 수 있다.
+
+```text
+[OK] warning broadcast service test passed.
+```
+
+## 참고 사항
+
+현재 단계에서는 실제 음성 출력을 수행하지 않고, 터미널 출력으로 방송 실행 흐름을 검증한다.
+
+후속 단계에서는 `execute_warning_broadcast()`가 선택한 `message`를 TTS 모듈에 전달하여 실제 음성 출력으로 확장할 수 있다.
+
+현재 cooldown 상태는 실행 중인 서버 또는 프로세스 메모리에서 관리된다. 서버를 재시작하면 cooldown 기록은 초기화된다.

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -1,52 +1,74 @@
 # Backend Services
 
-백엔드 서비스 계층은 AI 탐지 결과와 DB 저장 구조를 연결하는 역할을 수행한다.
+백엔드 서비스 계층은 AI 탐지 결과를 후보 이벤트 데이터로 변환하고, 저장된 경고 방송 설정에 따라 경고 메시지 출력 및 TTS 음성 방송을 수행하는 역할을 담당함.
 
-## Candidate Event Media Service
+---
 
-`candidate_event_service.py`는 AI 탐지 결과를 `candidate_event` DB 구조에 맞게 변환하고 저장한다.
+## 파일 구성
 
-주요 기능은 다음과 같다.
+| 파일 | 설명 |
+|---|---|
+| `candidate_event_service.py` | AI 탐지 결과를 후보 이벤트로 변환하고 DB 저장 및 경고 방송 실행을 연결함 |
+| `warning_broadcast_service.py` | 방송 설정 조회, 메시지 선택, cooldown 적용, 터미널 로그 및 TTS 실행을 처리함 |
+| `tts_service.py` | 선택된 경고 메시지를 실제 음성으로 출력함 |
+| `test_candidate_event_service.py` | 후보 이벤트 저장 및 썸네일 경로 생성 확인용 수동 테스트 |
+| `test_warning_broadcast_service.py` | 후보 이벤트 저장, 메시지 선택, cooldown, 방송 OFF, TTS 실행 확인용 수동 테스트 |
+| `test_tts_service.py` | 시스템 음성 목록 및 한국어·영어 TTS 단독 출력 확인용 수동 테스트 |
+
+---
+
+## 필요 패키지
+
+후보 이벤트 썸네일 저장과 TTS 음성 출력을 위해 아래 패키지를 사용함.
+
+```bash
+pip install opencv-python numpy pyttsx3
+```
+
+또는 `requirements.txt`를 사용하는 경우 아래 항목을 추가함.
+
+```text
+opencv-python
+numpy
+pyttsx3
+```
+
+| 패키지 | 사용 목적 |
+|---|---|
+| `opencv-python` | 후보 이벤트 썸네일 이미지 저장 |
+| `numpy` | 수동 테스트용 이미지 데이터 생성 |
+| `pyttsx3` | 경고 메시지 TTS 음성 출력 |
+
+---
+
+# Candidate Event Media Service
+
+## 개요
+
+`candidate_event_service.py`는 AI 탐지 결과를 `candidate_event` DB 구조에 맞게 변환하고 저장하는 서비스임.
+
+현재는 안전모 미착용 후보 이벤트 생성을 기준으로 구현되어 있으며, 후보 이벤트 저장 이후 경고 방송 실행 서비스까지 연결함.
+
+## 주요 기능
 
 - 후보 이벤트 ID 생성
 - 이벤트 썸네일 이미지 저장
 - 영상 또는 참조 클립 경로 정리
 - `candidate_event` DB 저장
+- 저장된 이벤트의 구역 정보 조회
+- 후보 이벤트 저장 후 경고 방송 실행 연결
 
-## 필요 패키지
-
-`candidate_event_service.py`는 이벤트 썸네일 이미지를 저장하기 위해 OpenCV를 사용한다.  
-수동 테스트 스크립트에서는 테스트 이미지를 생성하기 위해 NumPy도 사용한다.
-
-필요 패키지:
-
-```bash
-pip install opencv-python numpy
-```
-
-또는 `requirements.txt`를 사용하는 경우 아래 항목을 추가한다.
+## 처리 흐름
 
 ```text
-opencv-python
-numpy
+AI 안전모 미착용 탐지
+→ 후보 이벤트 ID 생성
+→ 썸네일 이미지 저장
+→ 영상 참조 경로 정리
+→ candidate_event DB 저장
+→ 저장된 이벤트의 zone_name 조회
+→ 경고 방송 실행 서비스 호출
 ```
-
-## 수동 테스트 방법
-
-DB를 초기화한 뒤 서비스 테스트 스크립트를 실행한다.
-
-```bash
-python backend/db/init_db.py
-python backend/services/test_candidate_event_service.py
-python backend/db/check_db.py
-```
-
-정상 동작 시 다음 내용을 확인할 수 있다.
-
-- `storage/candidate_events/thumbnails` 아래에 테스트 썸네일 이미지 생성
-- `candidate_event` 테이블에 새 후보 이벤트 저장
-- `thumbnail_path`에 프로젝트 기준 상대 경로 저장
-- `video_clip_path`에 참조 영상 경로 저장
 
 ## 사용 예시
 
@@ -59,85 +81,199 @@ saved_event = create_no_helmet_candidate_event(
     source_path="test_videos/test_video1.avi",
     frame_image=result.orig_img,
     model_version="helmet_yolov8n",
+    enable_tts=True,
 )
 
 print(saved_event["event_id"])
+print(saved_event["broadcast"])
+```
+
+`enable_tts` 값에 따라 실제 음성 출력 여부를 제어할 수 있음.
+
+```python
+# 실제 음성 방송까지 수행
+create_no_helmet_candidate_event(
+    camera_id="CAM_001",
+    confidence=0.88,
+    enable_tts=True,
+)
+
+# 터미널 로그만 출력
+create_no_helmet_candidate_event(
+    camera_id="CAM_001",
+    confidence=0.88,
+    enable_tts=False,
+)
 ```
 
 ## 저장 경로
 
-AI 탐지 결과로 생성된 후보 이벤트의 썸네일과 영상 참조 파일은 학습 데이터와 분리하기 위해 `storage/candidate_events` 아래에 저장한다.
+AI 탐지 결과로 생성된 후보 이벤트의 썸네일과 영상 참조 파일은 학습 데이터와 분리하기 위해 `storage/candidate_events` 아래에 저장함.
 
 | 경로 | 설명 |
 |---|---|
 | `storage/candidate_events/thumbnails` | 후보 이벤트 검토용 썸네일 이미지 |
 | `storage/candidate_events/clips` | 후보 이벤트 검토용 영상 클립 또는 참조 영상 |
 
-실제 생성되는 이미지와 영상 파일은 Git에 포함하지 않고, `.gitkeep`만 유지한다.
+실제 생성되는 이미지와 영상 파일은 Git에 포함하지 않고, `.gitkeep`만 유지함.
+
+## 수동 테스트 방법
+
+프로젝트 루트에서 DB 초기화 후 후보 이벤트 저장 테스트를 실행함.
+
+```bash
+python backend/db/init_db.py
+python -m backend.services.test_candidate_event_service
+python backend/db/check_db.py
+```
+
+정상 동작 시 다음 내용을 확인할 수 있음.
+
+- `storage/candidate_events/thumbnails` 아래에 테스트 썸네일 이미지 생성
+- `candidate_event` 테이블에 새 후보 이벤트 저장
+- `thumbnail_path`에 프로젝트 기준 상대 경로 저장
+- `video_clip_path`에 참조 영상 경로 저장
 
 ## 참고 사항
 
-현재 단계에서는 실제 짧은 클립 생성보다, 원본 영상 또는 추론 결과 영상 경로를 `video_clip_path`에 저장하는 구조를 우선 사용한다.
+현재 단계에서는 실제 짧은 클립 파일을 새로 생성하기보다, 원본 영상 또는 추론 결과 영상 경로를 `video_clip_path`에 저장하는 구조를 우선 사용함.
 
-짧은 영상 클립 생성 기능은 이후 `_save_clip()` 함수 등을 추가하여 확장할 수 있다.
+짧은 영상 클립 생성 기능은 이후 `_save_clip()` 함수 등을 추가하여 확장 가능함.
 
 ---
 
-## Warning Broadcast Service
+# Warning Broadcast Service
 
-`warning_broadcast_service.py`는 경고 방송 설정을 기반으로 PPE 미착용 후보 이벤트에 대한 방송 메시지를 선택하고, 1차 단계에서는 터미널 출력 방식으로 방송을 시뮬레이션한다.
+## 개요
 
-주요 기능은 다음과 같다.
+`warning_broadcast_service.py`는 저장된 경고 방송 설정을 조회하고, PPE 미착용 후보 이벤트에 맞는 경고 메시지를 선택하여 터미널 로그와 TTS 음성 방송을 실행하는 서비스임.
+
+## 주요 기능
 
 - 방송 사용 여부(`enabled`) 확인
 - 기본 언어(`default_language`) 기준 메시지 선택
 - PPE 유형 및 구역별 메시지 템플릿 선택
-- 특정 구역 템플릿이 없을 경우 전체 구역 템플릿 사용
+- 특정 구역 템플릿이 없을 경우 전체 구역 템플릿 적용
 - cooldown 시간 내 동일 상황의 중복 방송 방지
-- 방송 실행 결과를 dict와 터미널 로그 형태로 반환
+- 터미널 로그 출력
+- 선택적으로 TTS 음성 출력
+- 방송 실행 결과를 dict 형태로 반환
+
+## 방송 설정 연동 기준
+
+경고 방송 실행 서비스는 방송 설정 API를 통해 저장된 다음 값을 사용함.
+
+| 설정값 | 사용 목적 |
+|---|---|
+| `enabled` | 경고 방송 전체 사용 여부 확인 |
+| `default_language` | 기본 방송 언어 선택 |
+| `cooldown_sec` | 동일 상황의 반복 방송 제한 시간 |
+| `templates` | PPE 유형·구역·언어별 경고 메시지 선택 |
+
+메시지 템플릿은 다음 기준으로 관리됨.
+
+```text
+ppe_type
+zone_name
+language
+message
+```
+
+## 메시지 선택 우선순위
+
+동일한 PPE 유형과 언어에 대해 특정 구역용 템플릿과 전체 구역용 템플릿이 함께 존재할 경우, 특정 구역용 메시지를 우선 사용함.
+
+```text
+1순위: PPE 유형 + 특정 구역 + 언어가 모두 일치하는 템플릿
+2순위: PPE 유형 + 전체 구역("") + 언어가 일치하는 템플릿
+```
+
+예시:
+
+```text
+helmet / 프레스 구역 / ko / "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요."
+helmet / ""          / ko / "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
+```
+
+프레스 구역에서 안전모 미착용 이벤트가 발생하면 특정 구역 메시지를 사용하고, 다른 구역에서 발생하면 전체 구역 메시지를 사용함.
 
 ## 방송 실행 흐름
 
 ```text
-AI 탐지 결과 발생
-→ candidate_event 저장
+후보 이벤트 저장
 → 저장된 이벤트의 zone_name 조회
 → 경고 방송 설정 조회
-→ 메시지 선택
+→ enabled 확인
+→ PPE 유형·구역·언어에 맞는 메시지 선택
 → cooldown 확인
-→ 터미널 경고 메시지 출력
+→ 터미널 로그 출력
+→ enable_tts=True인 경우 TTS 음성 출력
 ```
 
 ## 터미널 출력 예시
 
+정상적으로 방송이 실행된 경우:
+
 ```text
 [WARNING BROADCAST]
-event_id=EVT_20260526153000_a1b2c3
+event_id=EVT_20260526203656_6f8745
 result=broadcast_printed
 ppe_type=helmet
 zone_name=프레스 구역
 language=ko
 message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
-executed_at=2026-05-26 15:30:00
+executed_at=2026-05-26 20:36:56
+tts_result=tts_completed
+tts_voice=Microsoft Heami Desktop - Korean
 ```
 
-cooldown으로 방송이 생략된 경우 다음과 같이 출력된다.
+cooldown으로 반복 방송이 생략된 경우:
 
 ```text
 [WARNING BROADCAST SKIPPED]
-event_id=EVT_20260526153000_a1b2c3
+event_id=EVT_20260526203656_6f8745
 result=cooldown_active
 ppe_type=helmet
 zone_name=프레스 구역
 language=ko
 message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
-cooldown_remaining_sec=30
-executed_at=2026-05-26 15:30:01
+cooldown_remaining_sec=25
+executed_at=2026-05-26 20:37:01
 ```
+
+방송 설정이 비활성화된 경우:
+
+```text
+[WARNING BROADCAST SKIPPED]
+event_id=TEST_DISABLED_EVENT
+result=broadcast_disabled
+ppe_type=helmet
+zone_name=프레스 구역
+language=ko
+executed_at=2026-05-26 20:37:01
+```
+
+## cooldown 처리 기준
+
+현재 cooldown은 실행 중인 프로세스 메모리에서 관리함.
+
+동일한 아래 조건의 방송이 cooldown 시간 내 다시 요청되면 음성 방송을 생략함.
+
+```text
+ppe_type + zone_name + language
+```
+
+예시:
+
+```text
+helmet + 프레스 구역 + ko
+```
+
+cooldown 상태는 프로세스를 종료하거나 `reset_broadcast_cooldown()`을 호출하면 초기화됨.
 
 ## 수동 테스트 방법
 
-DB 초기화 후 경고 방송 서비스 테스트 스크립트를 실행한다.
+프로젝트 루트에서 DB 초기화 후 경고 방송 서비스 테스트를 실행함.
 
 ```bash
 python backend/db/init_db.py
@@ -146,22 +282,131 @@ python -m backend.services.test_warning_broadcast_service
 
 테스트 항목:
 
-- 후보 이벤트 저장 후 경고 방송 출력 확인
-- PPE 유형 및 구역별 메시지 선택 확인
-- 기본 언어 변경 시 영어 메시지 선택 확인
-- cooldown 시간 내 재방송 생략 확인
-- 방송 비활성화 시 실행 생략 확인
+- 후보 이벤트 저장 후 구역별 한국어 메시지 선택 확인
+- 후보 이벤트 저장 후 한국어 TTS 음성 출력 확인
+- 동일 상황 재발생 시 cooldown 기반 반복 방송 차단 확인
+- 기본 언어 변경 시 영어 메시지 템플릿 선택 확인
+- 방송 비활성화 시 방송 실행 생략 확인
 
-정상 동작 시 다음 메시지를 확인할 수 있다.
+주의 사항:
+
+- 본 테스트는 실제 한국어 TTS 음성을 출력하는 수동 테스트임
+- Windows 환경에서는 설치된 시스템 음성을 사용함
+- 확인 환경에서는 `Microsoft Heami Desktop - Korean` 음성 출력이 정상 동작함
+
+정상 동작 시 다음 메시지를 확인할 수 있음.
 
 ```text
+tts_result=tts_completed
+tts_voice=Microsoft Heami Desktop - Korean
 [OK] warning broadcast service test passed.
+```
+
+---
+
+# TTS Service
+
+## 개요
+
+`tts_service.py`는 경고 방송 서비스에서 선택한 메시지를 실제 음성으로 출력하는 역할을 수행함.
+
+현재 구현에서는 `pyttsx3`를 사용하며, Windows 환경에서는 시스템에 설치된 음성 엔진을 사용함.
+
+## 주요 기능
+
+- 시스템에서 사용 가능한 음성 목록 조회
+- 요청 언어에 맞는 시스템 음성 선택
+- 한국어·영어 경고 메시지 음성 출력
+- TTS 실행 결과 반환
+
+## 실행 방식
+
+`execute_warning_broadcast()` 호출 시 `enable_tts=True`를 전달하면, 터미널 로그 출력 이후 실제 음성 방송을 수행함.
+
+```python
+from backend.services.warning_broadcast_service import execute_warning_broadcast
+
+result = execute_warning_broadcast(
+    event_id="EVT_TEST",
+    ppe_type="helmet",
+    zone_name="프레스 구역",
+    enable_tts=True,
+)
+
+print(result)
+```
+
+방송이 비활성화되어 있거나 cooldown으로 생략되는 경우에는 TTS도 실행되지 않음.
+
+## TTS 단독 수동 테스트
+
+프로젝트 루트에서 아래 명령어를 실행함.
+
+```bash
+python -m backend.services.test_tts_service
+```
+
+테스트 항목:
+
+- 시스템에 설치된 음성 목록 출력
+- 한국어 경고 메시지 음성 출력
+- 영어 경고 메시지 음성 출력
+
+정상 동작 시 한국어 및 영어 안내 음성이 실제로 출력되고, 마지막에 아래 메시지를 확인할 수 있음.
+
+```text
+[OK] TTS service test passed.
 ```
 
 ## 참고 사항
 
-현재 단계에서는 실제 음성 출력을 수행하지 않고, 터미널 출력으로 방송 실행 흐름을 검증한다.
+TTS 음성 품질과 사용 가능한 언어는 실행 환경에 설치된 시스템 음성에 따라 달라질 수 있음.
 
-후속 단계에서는 `execute_warning_broadcast()`가 선택한 `message`를 TTS 모듈에 전달하여 실제 음성 출력으로 확장할 수 있다.
+Windows에서 한국어 음성이 설치되어 있지 않은 경우, 한국어 메시지 출력이 실패하거나 사용할 수 있는 음성을 찾지 못할 수 있음.
 
-현재 cooldown 상태는 실행 중인 서버 또는 프로세스 메모리에서 관리된다. 서버를 재시작하면 cooldown 기록은 초기화된다.
+---
+
+# 전체 수동 테스트 순서
+
+프로젝트 루트에서 아래 순서로 실행함.
+
+```bash
+python backend/db/init_db.py
+python -m backend.services.test_candidate_event_service
+python -m backend.services.test_tts_service
+python -m backend.services.test_warning_broadcast_service
+python backend/db/check_db.py
+```
+
+확인 항목:
+
+- 후보 이벤트 저장 및 썸네일 경로 생성
+- TTS 단독 한국어·영어 음성 출력
+- 후보 이벤트 발생 후 방송 설정 기반 메시지 선택
+- 실제 한국어 TTS 경고 방송 출력
+- cooldown 기반 반복 방송 차단
+- 방송 OFF 설정 적용
+
+---
+
+# 현재 구현 범위 및 후속 확장
+
+## 현재 구현 완료 범위
+
+- 안전모 미착용 후보 이벤트 생성 및 DB 저장
+- 후보 이벤트 썸네일 이미지 저장
+- 미디어 참조 경로 정리
+- 경고 방송 설정값 조회 및 적용
+- PPE 유형·구역·언어별 메시지 선택
+- cooldown 기반 중복 방송 방지
+- 터미널 로그 출력
+- 한국어 TTS 경고 방송 출력 확인
+- 영어 TTS 단독 출력 확인
+
+## 후속 확장 대상
+
+- 안전조끼 미착용 이벤트 생성 흐름과 방송 실행 직접 연결
+- 실제 짧은 영상 클립 생성 및 저장
+- 방송 실행 이력 DB 저장
+- 서버 재시작 이후에도 유지되는 cooldown 관리
+- AI 탐지 코드에서 후보 이벤트 저장 서비스 호출 연결

--- a/backend/services/candidate_event_service.py
+++ b/backend/services/candidate_event_service.py
@@ -9,18 +9,23 @@ AI 탐지 결과를 candidate_event DB 구조에 맞게 변환하고 저장하�
 - 영상 또는 참조 클립 경로 정리
 - candidate_event dict 생성
 - DB 저장 함수 호출
+- 후보 이벤트 저장 후 경고 방송 실행
 
 이 서비스는 AI 탐지 코드에서 직접 DB 구조를 다루지 않도록 하기 위한 연결 계층이다.
 """
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional, Union
 from uuid import uuid4
 
 import cv2
 
-from backend.db.event_repository import insert_candidate_event
+from backend.db.event_repository import (
+    get_candidate_event_by_id,
+    insert_candidate_event,
+)
+from backend.services.warning_broadcast_service import execute_warning_broadcast
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -80,14 +85,14 @@ def _to_relative_path(path: Path) -> str:
     return str(path.relative_to(PROJECT_ROOT)).replace("\\", "/")
 
 
-def _save_thumbnail(event_id: str, frame_image: Any | None) -> str:
+def _save_thumbnail(event_id: str, frame_image: Optional[Any]) -> str:
     """
     이벤트 썸네일 이미지를 저장함.
 
     Args:
         event_id (str):
             후보 이벤트 ID.
-        frame_image:
+        frame_image (Optional[Any]):
             OpenCV 이미지 배열. 일반적으로 YOLO result.orig_img 사용.
 
     Returns:
@@ -109,12 +114,14 @@ def _save_thumbnail(event_id: str, frame_image: Any | None) -> str:
     return _to_relative_path(thumbnail_path)
 
 
-def _normalize_media_path(source_path: str | Path | None) -> str:
+def _normalize_media_path(
+    source_path: Optional[Union[str, Path]],
+) -> str:
     """
     영상 또는 참조 파일 경로를 프로젝트 루트 기준 상대 경로로 정리함.
 
     Args:
-        source_path (str | Path | None):
+        source_path (Optional[Union[str, Path]]):
             원본 영상, 추론 결과 영상, 또는 참조 클립 경로.
 
     Returns:
@@ -139,43 +146,43 @@ def create_no_helmet_candidate_event(
     *,
     camera_id: str,
     confidence: float,
-    source_path: str | Path | None = None,
-    frame_image: Any | None = None,
+    source_path: Optional[Union[str, Path]] = None,
+    frame_image: Optional[Any] = None,
     model_version: str = DEFAULT_MODEL_VERSION,
-    timestamp_start: str | None = None,
-    timestamp_end: str | None = None,
+    timestamp_start: Optional[str] = None,
+    timestamp_end: Optional[str] = None,
     duration_sec: int = 0,
     frame_sample_count: int = 1,
-    tracking_id: str | None = None,
+    tracking_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """
-    안전모 미착용 후보 이벤트를 생성하고 DB에 저장함.
+    안전모 미착용 후보 이벤트를 생성하고 DB에 저장한 뒤 경고 방송을 실행함.
 
     Args:
         camera_id (str):
             이벤트가 발생한 카메라 ID.
         confidence (float):
             AI 탐지 신뢰도.
-        source_path (str | Path | None):
+        source_path (Optional[Union[str, Path]]):
             원본 영상, 추론 결과 영상, 또는 참조 클립 경로.
-        frame_image:
+        frame_image (Optional[Any]):
             썸네일로 저장할 프레임 이미지.
         model_version (str):
             사용한 AI 모델 버전.
-        timestamp_start (str | None):
+        timestamp_start (Optional[str]):
             이벤트 시작 시각. 없으면 현재 시각 사용.
-        timestamp_end (str | None):
+        timestamp_end (Optional[str]):
             이벤트 종료 시각. 없으면 시작 시각과 동일하게 사용.
         duration_sec (int):
             이벤트 지속 시간.
         frame_sample_count (int):
             이벤트 판단에 사용한 프레임 수.
-        tracking_id (str | None):
+        tracking_id (Optional[str]):
             외부 추적 ID. 없으면 event_id 기반으로 생성.
 
     Returns:
         dict[str, Any]:
-            생성된 후보 이벤트 ID, 썸네일 경로, 영상 경로를 포함한 결과.
+            생성된 후보 이벤트 정보와 경고 방송 실행 결과.
     """
     event_id = _make_event_id()
     now = _now_str()
@@ -206,9 +213,22 @@ def create_no_helmet_candidate_event(
 
     insert_candidate_event(event)
 
+    saved_event = get_candidate_event_by_id(event_id)
+    zone_name = ""
+
+    if saved_event is not None:
+        zone_name = saved_event.get("zone_name") or ""
+
+    broadcast_result = execute_warning_broadcast(
+        event_id=event_id,
+        ppe_type=event["ppe_type"],
+        zone_name=zone_name,
+    )
+
     return {
         "event_id": event_id,
         "thumbnail_path": thumbnail_path,
         "video_clip_path": video_clip_path,
         "event_status": "pending",
+        "broadcast": broadcast_result,
     }

--- a/backend/services/candidate_event_service.py
+++ b/backend/services/candidate_event_service.py
@@ -154,6 +154,7 @@ def create_no_helmet_candidate_event(
     duration_sec: int = 0,
     frame_sample_count: int = 1,
     tracking_id: Optional[str] = None,
+    enable_tts: bool = True,
 ) -> dict[str, Any]:
     """
     안전모 미착용 후보 이벤트를 생성하고 DB에 저장한 뒤 경고 방송을 실행함.
@@ -179,6 +180,9 @@ def create_no_helmet_candidate_event(
             이벤트 판단에 사용한 프레임 수.
         tracking_id (Optional[str]):
             외부 추적 ID. 없으면 event_id 기반으로 생성.
+        enable_tts (bool):
+            True이면 경고 방송 메시지를 실제 음성으로 출력함.
+            False이면 터미널 로그만 출력함.
 
     Returns:
         dict[str, Any]:
@@ -223,6 +227,7 @@ def create_no_helmet_candidate_event(
         event_id=event_id,
         ppe_type=event["ppe_type"],
         zone_name=zone_name,
+        enable_tts=True,
     )
 
     return {

--- a/backend/services/test_candidate_event_tts_integration.py
+++ b/backend/services/test_candidate_event_tts_integration.py
@@ -1,0 +1,75 @@
+"""후보 이벤트 생성과 TTS 경고 방송 연동 수동 테스트 스크립트."""
+
+from typing import Optional
+
+from backend.db.event_repository import (
+    delete_candidate_event,
+    get_broadcast_settings,
+    save_broadcast_settings,
+)
+from backend.services.candidate_event_service import create_no_helmet_candidate_event
+from backend.services.warning_broadcast_service import reset_broadcast_cooldown
+
+
+TEST_SETTINGS = {
+    "enabled": True,
+    "default_language": "ko",
+    "cooldown_sec": 0,
+    "templates": [
+        {
+            "ppe_type": "helmet",
+            "zone_name": "프레스 구역",
+            "language": "ko",
+            "message": "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.",
+        },
+        {
+            "ppe_type": "helmet",
+            "zone_name": "",
+            "language": "ko",
+            "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.",
+        },
+    ],
+}
+
+
+def run_test() -> None:
+    original_settings = get_broadcast_settings()
+    created_event_id: Optional[str] = None
+
+    try:
+        save_broadcast_settings(TEST_SETTINGS)
+        reset_broadcast_cooldown()
+
+        print("\n[test] candidate event 저장 후 실제 TTS 경고 방송 출력")
+
+        saved_event = create_no_helmet_candidate_event(
+            camera_id="CAM_001",
+            confidence=0.88,
+            source_path="test_videos/test_video1.avi",
+            frame_image=None,
+            model_version="helmet_yolov8n",
+            enable_tts=True,
+        )
+
+        created_event_id = saved_event["event_id"]
+        broadcast_result = saved_event["broadcast"]
+
+        assert broadcast_result["executed"] is True
+        assert broadcast_result["reason"] == "broadcast_printed"
+        assert broadcast_result["zone_name"] == "프레스 구역"
+        assert broadcast_result["language"] == "ko"
+        assert broadcast_result["tts"]["spoken"] is True
+        assert broadcast_result["tts"]["reason"] == "tts_completed"
+
+        print("\n[OK] candidate event TTS integration test passed.")
+
+    finally:
+        if created_event_id is not None:
+            delete_candidate_event(created_event_id)
+
+        save_broadcast_settings(original_settings)
+        reset_broadcast_cooldown()
+
+
+if __name__ == "__main__":
+    run_test()

--- a/backend/services/test_tts_service.py
+++ b/backend/services/test_tts_service.py
@@ -1,0 +1,47 @@
+"""TTS 서비스 수동 테스트 스크립트."""
+
+from backend.services.tts_service import (
+    list_available_voices,
+    speak_message,
+)
+
+
+def run_test() -> None:
+    print("\n[available voices]")
+
+    voices = list_available_voices()
+
+    for index, voice in enumerate(voices, start=1):
+        print(f"{index}. {voice}")
+
+    print("\n[test 1] 한국어 TTS 출력")
+    korean_result = speak_message(
+        "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.",
+        "ko",
+    )
+    print(korean_result)
+
+    if not korean_result["spoken"]:
+        raise RuntimeError(
+            "한국어 음성 출력에 실패했습니다. "
+            "Windows에 한국어 음성이 설치되어 있는지 확인해 주세요."
+        )
+
+    print("\n[test 2] 영어 TTS 출력")
+    english_result = speak_message(
+        "Workers in this area, please check your helmet.",
+        "en",
+    )
+    print(english_result)
+
+    if not english_result["spoken"]:
+        raise RuntimeError(
+            "영어 음성 출력에 실패했습니다. "
+            "Windows에 영어 음성이 설치되어 있는지 확인해 주세요."
+        )
+
+    print("\n[OK] TTS service test passed.")
+
+
+if __name__ == "__main__":
+    run_test()

--- a/backend/services/test_warning_broadcast_service.py
+++ b/backend/services/test_warning_broadcast_service.py
@@ -70,6 +70,7 @@ def run_test() -> None:
             source_path="test_videos/test_video1.avi",
             frame_image=None,
             model_version="helmet_yolov8n",
+            enable_tts=False,
         )
 
         created_event_id = saved_event["event_id"]

--- a/backend/services/test_warning_broadcast_service.py
+++ b/backend/services/test_warning_broadcast_service.py
@@ -1,7 +1,8 @@
 """경고 방송 실행 서비스 수동 테스트 스크립트."""
 
-from typing import Optional
+from typing import Any, Optional
 
+import backend.services.warning_broadcast_service as broadcast_service
 from backend.db.event_repository import (
     delete_candidate_event,
     get_broadcast_settings,
@@ -55,8 +56,32 @@ TEST_SETTINGS_DISABLED = {
 }
 
 
+def mock_failed_tts(message: str, language: str) -> dict[str, Any]:
+    """
+    TTS 출력 실패 상황을 검증하기 위한 mock 함수.
+
+    Args:
+        message (str):
+            출력 대상 경고 메시지.
+        language (str):
+            방송 언어.
+
+    Returns:
+        dict[str, Any]:
+            TTS 실패 결과.
+    """
+    return {
+        "spoken": False,
+        "reason": "tts_error",
+        "language": language,
+        "message": message,
+        "error": "mock tts failure",
+    }
+
+
 def run_test() -> None:
     original_settings = get_broadcast_settings()
+    original_speak_message = broadcast_service.speak_message
     created_event_id: Optional[str] = None
 
     try:
@@ -70,7 +95,7 @@ def run_test() -> None:
             source_path="test_videos/test_video1.avi",
             frame_image=None,
             model_version="helmet_yolov8n",
-            enable_tts=False,
+            enable_tts=True,
         )
 
         created_event_id = saved_event["event_id"]
@@ -79,20 +104,26 @@ def run_test() -> None:
         assert first_broadcast["executed"] is True
         assert first_broadcast["reason"] == "broadcast_printed"
         assert first_broadcast["zone_name"] == "프레스 구역"
+        assert first_broadcast["language"] == "ko"
         assert (
             first_broadcast["message"]
             == "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요."
         )
+        assert first_broadcast["tts"]["spoken"] is True
+        assert first_broadcast["tts"]["reason"] == "tts_completed"
 
         print("\n[test 2] 동일 상황 재방송 cooldown 적용")
         duplicate_broadcast = execute_warning_broadcast(
             event_id=created_event_id,
             ppe_type="helmet",
             zone_name="프레스 구역",
+            enable_tts=True,
         )
 
         assert duplicate_broadcast["executed"] is False
         assert duplicate_broadcast["reason"] == "cooldown_active"
+        assert "cooldown_remaining_sec" in duplicate_broadcast
+        assert "tts" not in duplicate_broadcast
 
         print("\n[test 3] 기본 언어 English 및 전체 구역 템플릿 적용")
         save_broadcast_settings(TEST_SETTINGS_EN)
@@ -102,14 +133,17 @@ def run_test() -> None:
             event_id="TEST_VEST_EVENT",
             ppe_type="vest",
             zone_name="자재 이동 구역",
+            enable_tts=False,
         )
 
         assert english_broadcast["executed"] is True
+        assert english_broadcast["reason"] == "broadcast_printed"
         assert english_broadcast["language"] == "en"
         assert (
             english_broadcast["message"]
             == "Workers in this area, please check your safety vest."
         )
+        assert "tts" not in english_broadcast
 
         print("\n[test 4] 방송 OFF 설정 적용")
         save_broadcast_settings(TEST_SETTINGS_DISABLED)
@@ -119,14 +153,40 @@ def run_test() -> None:
             event_id="TEST_DISABLED_EVENT",
             ppe_type="helmet",
             zone_name="프레스 구역",
+            enable_tts=True,
         )
 
         assert disabled_broadcast["executed"] is False
         assert disabled_broadcast["reason"] == "broadcast_disabled"
+        assert "tts" not in disabled_broadcast
+
+        print("\n[test 5] TTS 실패 시 터미널 로그 fallback 처리")
+        save_broadcast_settings(TEST_SETTINGS_KO)
+        reset_broadcast_cooldown()
+
+        broadcast_service.speak_message = mock_failed_tts
+
+        failed_tts_broadcast = execute_warning_broadcast(
+            event_id="TEST_TTS_FAILURE_EVENT",
+            ppe_type="helmet",
+            zone_name="프레스 구역",
+            enable_tts=True,
+        )
+
+        assert failed_tts_broadcast["executed"] is True
+        assert failed_tts_broadcast["reason"] == "broadcast_printed"
+        assert (
+            failed_tts_broadcast["message"]
+            == "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요."
+        )
+        assert failed_tts_broadcast["tts"]["spoken"] is False
+        assert failed_tts_broadcast["tts"]["reason"] == "tts_error"
 
         print("\n[OK] warning broadcast service test passed.")
 
     finally:
+        broadcast_service.speak_message = original_speak_message
+
         if created_event_id is not None:
             delete_candidate_event(created_event_id)
 

--- a/backend/services/test_warning_broadcast_service.py
+++ b/backend/services/test_warning_broadcast_service.py
@@ -1,0 +1,137 @@
+"""경고 방송 실행 서비스 수동 테스트 스크립트."""
+
+from typing import Optional
+
+from backend.db.event_repository import (
+    delete_candidate_event,
+    get_broadcast_settings,
+    save_broadcast_settings,
+)
+from backend.services.candidate_event_service import create_no_helmet_candidate_event
+from backend.services.warning_broadcast_service import (
+    execute_warning_broadcast,
+    reset_broadcast_cooldown,
+)
+
+
+TEST_SETTINGS_KO = {
+    "enabled": True,
+    "default_language": "ko",
+    "cooldown_sec": 30,
+    "templates": [
+        {
+            "ppe_type": "helmet",
+            "zone_name": "프레스 구역",
+            "language": "ko",
+            "message": "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.",
+        },
+        {
+            "ppe_type": "helmet",
+            "zone_name": "",
+            "language": "ko",
+            "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요.",
+        },
+        {
+            "ppe_type": "vest",
+            "zone_name": "",
+            "language": "en",
+            "message": "Workers in this area, please check your safety vest.",
+        },
+    ],
+}
+
+TEST_SETTINGS_EN = {
+    "enabled": True,
+    "default_language": "en",
+    "cooldown_sec": 30,
+    "templates": TEST_SETTINGS_KO["templates"],
+}
+
+TEST_SETTINGS_DISABLED = {
+    "enabled": False,
+    "default_language": "ko",
+    "cooldown_sec": 30,
+    "templates": TEST_SETTINGS_KO["templates"],
+}
+
+
+def run_test() -> None:
+    original_settings = get_broadcast_settings()
+    created_event_id: Optional[str] = None
+
+    try:
+        print("\n[test 1] candidate event 저장 후 구역별 한국어 경고 방송 출력")
+        save_broadcast_settings(TEST_SETTINGS_KO)
+        reset_broadcast_cooldown()
+
+        saved_event = create_no_helmet_candidate_event(
+            camera_id="CAM_001",
+            confidence=0.88,
+            source_path="test_videos/test_video1.avi",
+            frame_image=None,
+            model_version="helmet_yolov8n",
+        )
+
+        created_event_id = saved_event["event_id"]
+        first_broadcast = saved_event["broadcast"]
+
+        assert first_broadcast["executed"] is True
+        assert first_broadcast["reason"] == "broadcast_printed"
+        assert first_broadcast["zone_name"] == "프레스 구역"
+        assert (
+            first_broadcast["message"]
+            == "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요."
+        )
+
+        print("\n[test 2] 동일 상황 재방송 cooldown 적용")
+        duplicate_broadcast = execute_warning_broadcast(
+            event_id=created_event_id,
+            ppe_type="helmet",
+            zone_name="프레스 구역",
+        )
+
+        assert duplicate_broadcast["executed"] is False
+        assert duplicate_broadcast["reason"] == "cooldown_active"
+
+        print("\n[test 3] 기본 언어 English 및 전체 구역 템플릿 적용")
+        save_broadcast_settings(TEST_SETTINGS_EN)
+        reset_broadcast_cooldown()
+
+        english_broadcast = execute_warning_broadcast(
+            event_id="TEST_VEST_EVENT",
+            ppe_type="vest",
+            zone_name="자재 이동 구역",
+        )
+
+        assert english_broadcast["executed"] is True
+        assert english_broadcast["language"] == "en"
+        assert (
+            english_broadcast["message"]
+            == "Workers in this area, please check your safety vest."
+        )
+
+        print("\n[test 4] 방송 OFF 설정 적용")
+        save_broadcast_settings(TEST_SETTINGS_DISABLED)
+        reset_broadcast_cooldown()
+
+        disabled_broadcast = execute_warning_broadcast(
+            event_id="TEST_DISABLED_EVENT",
+            ppe_type="helmet",
+            zone_name="프레스 구역",
+        )
+
+        assert disabled_broadcast["executed"] is False
+        assert disabled_broadcast["reason"] == "broadcast_disabled"
+
+        print("\n[OK] warning broadcast service test passed.")
+
+    finally:
+        if created_event_id is not None:
+            delete_candidate_event(created_event_id)
+
+        save_broadcast_settings(original_settings)
+        reset_broadcast_cooldown()
+
+
+if __name__ == "__main__":
+    run_test()

--- a/backend/services/tts_service.py
+++ b/backend/services/tts_service.py
@@ -1,0 +1,172 @@
+"""
+tts_service.py
+
+경고 방송 메시지를 실제 음성으로 출력하는 TTS 서비스 파일.
+
+역할:
+- 시스템에 설치된 음성 목록 조회
+- 언어별 사용 가능한 음성 선택
+- 경고 메시지 음성 출력
+- 출력 결과 dict 반환
+
+현재 구현은 pyttsx3를 사용하며, Windows에서는 설치된 시스템 음성을 사용함.
+"""
+
+from typing import Any, Optional
+
+
+VOICE_KEYWORDS = {
+    "ko": ["ko-kr", "korean", "heami", "sunhi", "한국"],
+    "en": ["en-us", "english", "david", "zira", "aria", "guy"],
+}
+
+
+def _load_pyttsx3() -> Any:
+    """
+    pyttsx3 모듈을 로드함.
+
+    Returns:
+        Any:
+            pyttsx3 모듈.
+
+    Raises:
+        RuntimeError:
+            pyttsx3가 설치되어 있지 않은 경우.
+    """
+    try:
+        import pyttsx3
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "pyttsx3 is not installed. Run: pip install pyttsx3"
+        ) from exc
+
+    return pyttsx3
+
+
+def _get_voice_description(voice: Any) -> str:
+    """
+    음성 객체의 검색용 설명 문자열을 생성함.
+
+    Args:
+        voice (Any):
+            pyttsx3 voice 객체.
+
+    Returns:
+        str:
+            음성 ID, 이름, 언어 정보를 합친 소문자 문자열.
+    """
+    voice_id = str(getattr(voice, "id", ""))
+    voice_name = str(getattr(voice, "name", ""))
+    voice_languages = " ".join(
+        str(language) for language in getattr(voice, "languages", [])
+    )
+
+    return f"{voice_id} {voice_name} {voice_languages}".lower()
+
+
+def _select_voice(voices: list[Any], language: str) -> Optional[Any]:
+    """
+    요청 언어에 맞는 시스템 음성을 선택함.
+
+    Args:
+        voices (list[Any]):
+            시스템에 설치된 음성 목록.
+        language (str):
+            방송 언어. "ko" 또는 "en".
+
+    Returns:
+        Optional[Any]:
+            선택된 음성 객체. 찾지 못하면 None.
+    """
+    keywords = VOICE_KEYWORDS.get(language, [])
+
+    for voice in voices:
+        description = _get_voice_description(voice)
+
+        if any(keyword in description for keyword in keywords):
+            return voice
+
+    return None
+
+
+def list_available_voices() -> list[dict[str, str]]:
+    """
+    시스템에서 사용할 수 있는 음성 목록을 반환함.
+
+    Returns:
+        list[dict[str, str]]:
+            음성 ID, 이름, 언어 정보 목록.
+    """
+    pyttsx3 = _load_pyttsx3()
+    engine = pyttsx3.init()
+
+    try:
+        voices = engine.getProperty("voices")
+
+        return [
+            {
+                "id": str(getattr(voice, "id", "")),
+                "name": str(getattr(voice, "name", "")),
+                "languages": str(getattr(voice, "languages", [])),
+            }
+            for voice in voices
+        ]
+    finally:
+        engine.stop()
+
+
+def speak_message(message: str, language: str) -> dict[str, Any]:
+    """
+    경고 방송 메시지를 실제 음성으로 출력함.
+
+    Args:
+        message (str):
+            음성으로 출력할 경고 메시지.
+        language (str):
+            방송 언어. "ko" 또는 "en".
+
+    Returns:
+        dict[str, Any]:
+            음성 출력 성공 여부와 사용 음성 정보.
+    """
+    pyttsx3 = _load_pyttsx3()
+    engine = pyttsx3.init()
+
+    try:
+        voices = engine.getProperty("voices")
+        selected_voice = _select_voice(voices, language)
+
+        if selected_voice is None:
+            return {
+                "spoken": False,
+                "reason": "voice_not_found",
+                "language": language,
+                "message": message,
+            }
+
+        engine.setProperty("voice", selected_voice.id)
+        engine.setProperty("rate", 170)
+
+        engine.say(message)
+        engine.runAndWait()
+
+        return {
+            "spoken": True,
+            "reason": "tts_completed",
+            "language": language,
+            "message": message,
+            "voice_id": str(selected_voice.id),
+            "voice_name": str(getattr(selected_voice, "name", "")),
+        }
+
+    except Exception as exc:
+        return {
+            "spoken": False,
+            "reason": "tts_error",
+            "language": language,
+            "message": message,
+            "error": str(exc),
+        }
+
+    finally:
+        engine.stop()

--- a/backend/services/warning_broadcast_service.py
+++ b/backend/services/warning_broadcast_service.py
@@ -1,0 +1,206 @@
+"""
+warning_broadcast_service.py
+
+경고 방송 설정을 조회하고, PPE 미착용 후보 이벤트에 대한
+터미널 기반 경고 방송을 실행하는 서비스 파일.
+
+현재 단계의 역할:
+- 경고 방송 사용 여부 확인
+- PPE 유형/구역/언어에 맞는 메시지 선택
+- cooldown 기반 중복 방송 방지
+- 터미널 기반 방송 시뮬레이션
+- 방송 실행 결과 dict 반환
+
+실제 TTS 음성 출력은 후속 단계에서 확장한다.
+"""
+
+import math
+from datetime import datetime
+from time import monotonic
+from typing import Any, Optional, Tuple
+
+from backend.db.event_repository import get_broadcast_settings
+
+
+_last_broadcast_at: dict[Tuple[str, str, str], float] = {}
+
+
+def _now_str() -> str:
+    """
+    현재 시간을 로그 반환용 문자열로 생성함.
+    """
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _select_broadcast_message(
+    templates: list[dict[str, Any]],
+    ppe_type: str,
+    zone_name: str,
+    language: str,
+) -> Optional[str]:
+    """
+    PPE 유형, 구역, 언어에 맞는 경고 메시지를 선택함.
+
+    선택 우선순위:
+    1. PPE 유형 + 특정 구역 + 언어가 모두 일치하는 템플릿
+    2. PPE 유형 + 전체 구역("") + 언어가 일치하는 템플릿
+
+    Args:
+        templates (list[dict[str, Any]]):
+            저장된 경고 방송 메시지 템플릿 목록.
+        ppe_type (str):
+            PPE 유형. 예: "helmet", "vest"
+        zone_name (str):
+            이벤트 발생 구역명.
+        language (str):
+            사용할 방송 언어. 예: "ko", "en"
+
+    Returns:
+        Optional[str]:
+            선택된 메시지. 사용할 템플릿이 없으면 None.
+    """
+    candidate_zones = [zone_name]
+
+    if zone_name != "":
+        candidate_zones.append("")
+
+    for target_zone in candidate_zones:
+        for template in templates:
+            if (
+                template["ppe_type"] == ppe_type
+                and template["zone_name"] == target_zone
+                and template["language"] == language
+            ):
+                return str(template["message"])
+
+    return None
+
+
+def _print_broadcast_result(result: dict[str, Any]) -> None:
+    """
+    방송 실행 결과를 터미널에 로그 형태로 출력함.
+
+    Args:
+        result (dict[str, Any]):
+            방송 실행 결과.
+    """
+    title = "[WARNING BROADCAST]" if result["executed"] else "[WARNING BROADCAST SKIPPED]"
+
+    print(f"\n{title}")
+    print(f"event_id={result['event_id']}")
+    print(f"result={result['reason']}")
+    print(f"ppe_type={result['ppe_type']}")
+    print(f"zone_name={result['zone_name']}")
+    print(f"language={result['language']}")
+
+    if result["message"] != "":
+        print(f"message={result['message']}")
+
+    if "cooldown_remaining_sec" in result:
+        print(f"cooldown_remaining_sec={result['cooldown_remaining_sec']}")
+
+    print(f"executed_at={result['executed_at']}")
+
+
+def reset_broadcast_cooldown() -> None:
+    """
+    메모리에 저장된 cooldown 상태를 초기화함.
+
+    Notes:
+        수동 테스트 및 추후 반복 시연 시 사용함.
+    """
+    _last_broadcast_at.clear()
+
+
+def execute_warning_broadcast(
+    *,
+    ppe_type: str,
+    zone_name: str = "",
+    event_id: Optional[str] = None,
+    language: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    경고 방송 설정에 따라 터미널 기반 경고 방송을 실행함.
+
+    Args:
+        ppe_type (str):
+            미착용이 감지된 PPE 유형.
+        zone_name (str):
+            이벤트 발생 구역명.
+        event_id (Optional[str]):
+            연결된 후보 이벤트 ID.
+        language (Optional[str]):
+            강제로 사용할 언어. 지정하지 않으면 기본 방송 언어 사용.
+
+    Returns:
+        dict[str, Any]:
+            방송 실행 여부, 생략 사유, 메시지, 실행 시각 등을 포함한 결과.
+    """
+    settings = get_broadcast_settings()
+    selected_language = language or settings.get("default_language", "ko")
+    executed_at = _now_str()
+
+    base_result = {
+        "event_id": event_id or "",
+        "ppe_type": ppe_type,
+        "zone_name": zone_name,
+        "language": selected_language,
+        "message": "",
+        "executed_at": executed_at,
+    }
+
+    if not settings.get("enabled", False):
+        result = {
+            **base_result,
+            "executed": False,
+            "reason": "broadcast_disabled",
+        }
+        _print_broadcast_result(result)
+        return result
+
+    message = _select_broadcast_message(
+        templates=settings.get("templates", []),
+        ppe_type=ppe_type,
+        zone_name=zone_name,
+        language=selected_language,
+    )
+
+    if message is None:
+        result = {
+            **base_result,
+            "executed": False,
+            "reason": "template_not_found",
+        }
+        _print_broadcast_result(result)
+        return result
+
+    cooldown_sec = max(int(settings.get("cooldown_sec", 0)), 0)
+    cooldown_key = (ppe_type, zone_name, selected_language)
+    current_time = monotonic()
+    previous_time = _last_broadcast_at.get(cooldown_key)
+
+    if previous_time is not None:
+        elapsed_sec = current_time - previous_time
+
+        if elapsed_sec < cooldown_sec:
+            result = {
+                **base_result,
+                "message": message,
+                "executed": False,
+                "reason": "cooldown_active",
+                "cooldown_remaining_sec": math.ceil(cooldown_sec - elapsed_sec),
+            }
+            _print_broadcast_result(result)
+            return result
+
+    _last_broadcast_at[cooldown_key] = current_time
+
+    result = {
+        **base_result,
+        "message": message,
+        "executed": True,
+        "reason": "broadcast_printed",
+    }
+
+    _print_broadcast_result(result)
+    return result

--- a/backend/services/warning_broadcast_service.py
+++ b/backend/services/warning_broadcast_service.py
@@ -20,6 +20,7 @@ from time import monotonic
 from typing import Any, Optional, Tuple
 
 from backend.db.event_repository import get_broadcast_settings
+from backend.services.tts_service import speak_message
 
 
 _last_broadcast_at: dict[Tuple[str, str, str], float] = {}
@@ -118,6 +119,7 @@ def execute_warning_broadcast(
     zone_name: str = "",
     event_id: Optional[str] = None,
     language: Optional[str] = None,
+    enable_tts: bool = False,
 ) -> dict[str, Any]:
     """
     경고 방송 설정에 따라 터미널 기반 경고 방송을 실행함.
@@ -131,6 +133,8 @@ def execute_warning_broadcast(
             연결된 후보 이벤트 ID.
         language (Optional[str]):
             강제로 사용할 언어. 지정하지 않으면 기본 방송 언어 사용.
+                    enable_tts (bool):
+            True이면 터미널 출력 후 실제 음성 출력을 수행함.
 
     Returns:
         dict[str, Any]:
@@ -200,7 +204,21 @@ def execute_warning_broadcast(
         "message": message,
         "executed": True,
         "reason": "broadcast_printed",
+        "tts_enabled": enable_tts,
     }
 
     _print_broadcast_result(result)
+
+    if enable_tts:
+        tts_result = speak_message(
+            message=message,
+            language=selected_language,
+        )
+        result["tts"] = tts_result
+
+        print(f"tts_result={tts_result['reason']}")
+
+        if tts_result.get("voice_name"):
+            print(f"tts_voice={tts_result['voice_name']}")
+
     return result


### PR DESCRIPTION
대응 이슈: issue #49

## 개요

PPE 미착용 후보 이벤트가 발생했을 때 저장된 경고 방송 설정을 조회하여 메시지를 선택하고, 터미널 로그 및 TTS 음성 출력으로 경고 방송을 실행할 수 있도록 구현함.

기존에는 방송 ON/OFF, 기본 언어, cooldown, 메시지 템플릿을 설정하고 저장하는 기반만 마련되어 있었음.  
이번 작업에서는 해당 설정값을 실제 후보 이벤트 발생 흐름에 연결하여, 안전모 미착용 후보 이벤트 저장 이후 조건에 맞는 경고 메시지를 출력하고 실제 음성 방송까지 수행할 수 있도록 확장함.

---

## 작업 내용

### 1. 경고 방송 실행 서비스 추가

`backend/services/warning_broadcast_service.py`를 추가하여 경고 방송 실행 흐름을 구현함.

주요 기능:

- 방송 사용 여부(`enabled`) 확인
- 기본 방송 언어(`default_language`) 적용
- PPE 유형·구역·언어별 메시지 템플릿 선택
- 특정 구역용 템플릿 우선 적용
- 특정 구역용 템플릿이 없을 경우 전체 구역용 템플릿 fallback
- cooldown 시간 내 동일 상황의 중복 방송 차단
- 방송 실행 결과를 dict 형태로 반환
- 방송 실행 및 생략 결과를 터미널 로그로 출력

메시지 선택 우선순위:

```text
1순위: PPE 유형 + 특정 구역 + 언어가 모두 일치하는 템플릿
2순위: PPE 유형 + 전체 구역("") + 언어가 일치하는 템플릿
```

---

### 2. 후보 이벤트 생성 흐름과 방송 실행 연결

`backend/services/candidate_event_service.py`에서 안전모 미착용 후보 이벤트 저장 이후 경고 방송 실행 서비스를 호출하도록 연결함.

처리 흐름:

```text
안전모 미착용 후보 이벤트 생성
→ candidate_event DB 저장
→ 저장된 이벤트의 zone_name 조회
→ 경고 방송 설정 조회
→ 조건에 맞는 메시지 선택
→ cooldown 확인
→ 터미널 로그 출력
→ enable_tts=True인 경우 TTS 음성 출력
```

`create_no_helmet_candidate_event()` 호출 시 `enable_tts` 값으로 실제 음성 출력 여부를 제어할 수 있도록 구성함.

```python
# 실제 음성 방송 수행
create_no_helmet_candidate_event(
    camera_id="CAM_001",
    confidence=0.88,
    enable_tts=True,
)

# 터미널 로그만 출력
create_no_helmet_candidate_event(
    camera_id="CAM_001",
    confidence=0.88,
    enable_tts=False,
)
```

---

### 3. TTS 음성 출력 서비스 추가

`backend/services/tts_service.py`를 추가하여 선택된 경고 메시지를 실제 음성으로 출력할 수 있도록 구현함.

구현 내용:

- `pyttsx3` 기반 로컬 TTS 출력
- 시스템에 설치된 음성 목록 조회
- 한국어·영어별 사용 가능한 음성 선택
- TTS 실행 성공/실패 결과 반환
- Windows 시스템 음성을 활용한 실제 경고 방송 출력

실행 확인 환경에서는 한국어 출력 시 아래 음성이 정상 선택됨.

```text
Microsoft Heami Desktop - Korean
```

---

### 4. cooldown 기반 중복 방송 방지

동일한 상황이 반복 감지될 경우 설정된 cooldown 시간 동안 경고 방송이 반복 실행되지 않도록 처리함.

현재 동일 상황 판단 기준:

```text
ppe_type + zone_name + language
```

예시:

```text
helmet + 프레스 구역 + ko
```

cooldown이 적용된 경우 터미널 로그에 남은 대기 시간을 함께 출력함.

```text
result=cooldown_active
cooldown_remaining_sec=25
```

현재 cooldown 기록은 실행 중인 프로세스 메모리에서 관리하며, 프로세스 재시작 시 초기화됨.

---

### 5. TTS 실패 시 터미널 로그 fallback 처리

TTS 음성 출력이 실패하더라도 경고 메시지와 실행 결과를 터미널 로그에서 확인할 수 있도록 처리함.

동작 흐름:

```text
경고 메시지 선택
→ 터미널 로그 출력
→ TTS 실행 시도
→ TTS 실패 시 tts_error 결과 기록
```

TTS 실패 상황에서도 아래 정보는 유지됨.

- 이벤트 ID
- PPE 유형
- 발생 구역
- 방송 언어
- 선택된 경고 메시지
- 실행 시각
- TTS 실패 결과

---

### 6. 수동 테스트 및 서비스 문서 정리

다음 수동 테스트 파일과 문서를 추가·수정함.

- `backend/services/test_warning_broadcast_service.py`
  - 후보 이벤트 저장 후 한국어 TTS 음성 출력 확인
  - cooldown 적용 확인
  - 영어 메시지 템플릿 선택 확인
  - 방송 OFF 설정 적용 확인
  - TTS 실패 시 터미널 로그 fallback 확인

- `backend/services/test_tts_service.py`
  - 시스템 음성 목록 확인
  - 한국어 TTS 단독 출력 확인
  - 영어 TTS 단독 출력 확인

- `backend/services/README.md`
  - 후보 이벤트 저장 서비스 설명 정리
  - 경고 방송 실행 흐름 추가
  - TTS 실행 방식 및 테스트 방법 추가
  - cooldown 및 fallback 처리 기준 정리

---

## 실행 결과 예시

### 1. 후보 이벤트 발생 후 한국어 TTS 방송 실행

```text
[WARNING BROADCAST]
event_id=EVT_20260526203656_6f8745
result=broadcast_printed
ppe_type=helmet
zone_name=프레스 구역
language=ko
message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
executed_at=2026-05-26 20:36:56
tts_result=tts_completed
tts_voice=Microsoft Heami Desktop - Korean
```

### 2. cooldown으로 반복 방송 생략

```text
[WARNING BROADCAST SKIPPED]
event_id=EVT_20260526203656_6f8745
result=cooldown_active
ppe_type=helmet
zone_name=프레스 구역
language=ko
message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
cooldown_remaining_sec=25
executed_at=2026-05-26 20:37:01
```

### 3. 방송 OFF 설정 적용

```text
[WARNING BROADCAST SKIPPED]
event_id=TEST_DISABLED_EVENT
result=broadcast_disabled
ppe_type=helmet
zone_name=프레스 구역
language=ko
executed_at=2026-05-26 20:37:01
```

### 4. TTS 실패 시 fallback 처리

```text
[WARNING BROADCAST]
event_id=TEST_TTS_FAILURE_EVENT
result=broadcast_printed
ppe_type=helmet
zone_name=프레스 구역
language=ko
message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
executed_at=2026-05-26 20:47:52
tts_result=tts_error
```

---

## 확인 내용

프로젝트 루트에서 아래 순서로 테스트함.

```bash
python backend/db/init_db.py
python -m backend.services.test_tts_service
python -m backend.services.test_warning_broadcast_service
```

확인 결과:

- 한국어 TTS 음성 출력 정상 동작 확인
- 영어 TTS 단독 출력 가능 여부 확인
- 후보 이벤트 저장 이후 구역별 한국어 경고 메시지 선택 확인
- 후보 이벤트 발생 후 실제 한국어 TTS 방송 출력 확인
- 동일 상황 반복 발생 시 cooldown 기반 재방송 차단 확인
- 방송 OFF 설정 적용 시 방송 실행 생략 확인
- TTS 실패 시에도 터미널 로그가 유지되는 fallback 처리 확인

정상 테스트 결과:

```text
tts_result=tts_completed
tts_voice=Microsoft Heami Desktop - Korean
[OK] warning broadcast service test passed.
```

---

## 영향 범위

- `backend/services/candidate_event_service.py`
- `backend/services/warning_broadcast_service.py`
- `backend/services/tts_service.py`
- `backend/services/test_warning_broadcast_service.py`
- `backend/services/test_tts_service.py`
- `backend/services/README.md`
- `backend/requirements.txt`

---

## 참고 사항

- 현재 실제 후보 이벤트 생성 흐름과 직접 연결된 PPE 유형은 안전모(`helmet`) 미착용임.
- 안전조끼(`vest`) 메시지 템플릿은 설정 및 선택 구조에서 지원하며, 실제 AI 이벤트 생성 흐름 연결은 후속 확장 가능함.
- 현재 cooldown 상태는 프로세스 메모리에서 관리되며, 서버 재시작 이후에도 유지되는 영구 저장 방식은 후속 확장 대상임.
- 방송 실행 이력은 현재 터미널 로그와 반환 데이터 형태로 확인 가능하며, DB 기반 이력 저장은 후속 확장 대상임.
- 실제 AI 탐지 코드에서 `create_no_helmet_candidate_event()`를 호출하도록 연결하는 작업은 AI 담당자와의 통합 단계에서 진행 예정임.