### PR TITLE
Implement helmet detection event logging (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,22 +18,44 @@ backend/db/*.db
 node_modules/
 frontend/dist/
 
-# Datasets and large binary files (never commit raw data)
+# Data folders
 data/raw/
+data/processed/
+data/merged/
+
+# Large archives
 *.zip
 *.7z
 *.tar
 *.gz
 
-# Model weights (download separately — see README)
+# Model weights
 *.pt
 *.onnx
 *.pth
 
-storage/candidate_events/thumbnails/*
-!storage/candidate_events/thumbnails/.gitkeep
+# YOLO output results
+runs/
 
-storage/candidate_events/clips/*
-!storage/candidate_events/clips/.gitkeep
+# Test images
+test_images/
 
-.env
+# Event logs
+events/
+
+# Test videos
+test_videos/
+test_vedios/
+
+# Event thumbnails
+backend/media/
+
+# Local detection logs
+detect_log.txt
+
+# Event thumbnails
+backend/media/
+
+# Test videos
+test_videos/
+test_vedios/

--- a/src/detect_ppe.py
+++ b/src/detect_ppe.py
@@ -1,0 +1,30 @@
+from ultralytics import YOLO
+from pathlib import Path
+
+
+MODEL_PATH = "runs/detect/helmet_yolov8n/weights/best.pt"
+SOURCE_PATH = "test_videos/test_video1.avi"
+
+
+def main():
+    model_path = Path(MODEL_PATH)
+
+    if not model_path.exists():
+        print(f"학습된 PPE 모델이 없습니다: {MODEL_PATH}")
+        print("임시로 기본 YOLO 모델 yolov8n.pt를 사용합니다.")
+        model = YOLO("yolov8n.pt")
+    else:
+        model = YOLO(MODEL_PATH)
+
+    results = model.predict(
+        source=SOURCE_PATH,
+        save=True,
+        conf=0.25
+    )
+
+    print("PPE detection completed")
+    print(f"result count: {len(results)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/helmet_event_logger.py
+++ b/src/helmet_event_logger.py
@@ -1,0 +1,173 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+from uuid import uuid4
+
+import cv2
+from ultralytics import YOLO
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT))
+
+from backend.db.event_repository import insert_candidate_event
+
+
+MODEL_PATH = "runs/detect/helmet_yolov8n/weights/best.pt"
+SOURCE_PATH = "test_videos/test_video1.avi"
+
+CAMERA_ID = "CAM_001"
+MODEL_VERSION = "helmet_yolov8n"
+
+PERSON_CLASS_NAME = "Person"
+HELMET_CLASS_NAME = "helmet"
+NO_HELMET_CLASS_NAME = "no_helmet"
+
+THUMBNAIL_DIR = "backend/media/event_thumbnails"
+
+
+def now_str():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def make_event_id():
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    short_id = uuid4().hex[:6]
+    return f"EVT_{timestamp}_{short_id}"
+
+
+def save_event_thumbnail(result, event_id):
+    thumbnail_dir = Path(THUMBNAIL_DIR)
+    thumbnail_dir.mkdir(parents=True, exist_ok=True)
+
+    thumbnail_path = thumbnail_dir / f"{event_id}.jpg"
+
+    # bbox가 그려진 프레임 이미지 생성
+    annotated_frame = result.plot()
+
+    cv2.imwrite(str(thumbnail_path), annotated_frame)
+
+    return str(thumbnail_path)
+
+
+def save_no_helmet_event(result, source_name, confidence, person_index):
+    event_id = make_event_id()
+    timestamp = now_str()
+
+    thumbnail_path = save_event_thumbnail(result, event_id)
+
+    event = {
+        "event_id": event_id,
+        "camera_id": CAMERA_ID,
+        "tracking_id": f"TRK_{event_id}",
+        "ppe_type": "helmet",
+        "timestamp_start": timestamp,
+        "timestamp_end": timestamp,
+        "duration_sec": 0,
+        "frame_sample_count": 1,
+        "thumbnail_path": thumbnail_path,
+        "video_clip_path": str(source_name),
+        "ai_confidence": float(confidence),
+        "person_detected": 1,
+        "ppe_detected": 0,
+        "model_version": MODEL_VERSION,
+        "event_status": "pending",
+    }
+
+    insert_candidate_event(event)
+
+    print(f"DB 저장 완료: {event_id}")
+    print(f"작업자 {person_index} / confidence={confidence:.2f}")
+    print(f"이벤트 캡처 저장: {thumbnail_path}")
+
+
+def main():
+    model_path = Path(MODEL_PATH)
+
+    if not model_path.exists():
+        raise FileNotFoundError(
+            f"학습된 안전모 모델을 찾을 수 없습니다: {MODEL_PATH}"
+        )
+
+    source_path = Path(SOURCE_PATH)
+
+    if not source_path.exists():
+        raise FileNotFoundError(
+            f"분석할 입력 파일을 찾을 수 없습니다: {SOURCE_PATH}"
+        )
+
+    model = YOLO(MODEL_PATH)
+
+    results = model.predict(
+        source=SOURCE_PATH,
+        save=True,
+        conf=0.25
+    )
+
+    for result in results:
+        source_name = Path(result.path).name
+        names = model.names
+
+        person_count = 0
+        helmet_count = 0
+        no_helmet_count = 0
+        max_no_helmet_confidence = 0.0
+
+        print(f"\n파일: {source_name}")
+
+        for box in result.boxes:
+            cls_id = int(box.cls[0])
+            cls_name = names[cls_id]
+            confidence = float(box.conf[0])
+
+            if cls_name == PERSON_CLASS_NAME:
+                person_count += 1
+
+            elif cls_name == HELMET_CLASS_NAME:
+                helmet_count += 1
+
+            elif cls_name == NO_HELMET_CLASS_NAME:
+                no_helmet_count += 1
+                max_no_helmet_confidence = max(max_no_helmet_confidence, confidence)
+
+        print(f"Person 탐지 수: {person_count}")
+        print(f"helmet 탐지 수: {helmet_count}")
+        print(f"no_helmet 탐지 수: {no_helmet_count}")
+
+        if no_helmet_count > 0:
+            print(f"no_helmet 직접 탐지: {no_helmet_count}건")
+
+            save_no_helmet_event(
+                result=result,
+                source_name=source_name,
+                confidence=max_no_helmet_confidence,
+                person_index=1
+            )
+
+            print("\n이벤트 1건 저장 후 분석을 종료합니다.")
+            return
+
+        print("no_helmet 직접 탐지 없음")
+
+        missing_helmet_count = person_count - helmet_count
+
+        if missing_helmet_count > 0:
+            print(f"보조 규칙 적용: 안전모 미착용 후보 {missing_helmet_count}명")
+
+            save_no_helmet_event(
+                result=result,
+                source_name=source_name,
+                confidence=0.50,
+                person_index=1
+            )
+
+            print("\n이벤트 1건 저장 후 분석을 종료합니다.")
+            return
+
+        print("보조 규칙 기준 안전모 미착용 후보 없음")
+
+    print("\n안전모 미착용 이벤트가 없어 저장하지 않았습니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train_ppe.py
+++ b/src/train_ppe.py
@@ -1,0 +1,31 @@
+from ultralytics import YOLO
+from pathlib import Path
+
+
+DATA_YAML = "data/raw/public_datasets/construction_ppe/data.yaml"
+BASE_MODEL = "yolov8n.pt"
+
+
+def main():
+    data_path = Path(DATA_YAML)
+
+    if not data_path.exists():
+        raise FileNotFoundError(
+            f"데이터셋 설정 파일을 찾을 수 없습니다: {DATA_YAML}"
+        )
+
+    model = YOLO(BASE_MODEL)
+
+    model.train(
+        data=DATA_YAML,
+        epochs=3,
+        imgsz=416,
+        batch=4,
+        name="helmet_yolov8n"
+    )
+
+    print("Helmet model training completed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 작업 내용

김순겸 담당 AI 탐지 파트 구현 내용입니다.

- YOLO 기반 안전모 탐지 테스트 코드 작성
- construction_ppe 데이터셋을 활용한 안전모 감지 모델 학습 코드 정리
- 학습된 helmet_yolov8n 모델을 이용한 이미지 및 영상 추론 테스트
- no_helmet 직접 탐지 및 Person/helmet 수 비교 기반 보조 규칙 구현
- 안전모 미착용 후보 발생 시 candidate_event DB 저장 기능 구현
- 이벤트 발생 프레임을 bbox 포함 이미지로 캡처 저장
- 저장된 캡처 이미지 경로를 candidate_event.thumbnail_path에 기록
- 테스트 영상, 탐지 결과, 캡처 이미지, 로그 파일 등 로컬 실행 결과물 .gitignore 처리

## 확인한 내용

- YOLO 모델 학습 후 best.pt 생성 확인
- 테스트 이미지에서 Person, helmet 탐지 확인
- test_video1.avi 영상에 대해 프레임 단위 추론 확인
- 안전모 미착용 후보 발생 시 candidate_event에 pending 상태로 저장 확인
- backend/media/event_thumbnails 경로에 이벤트 캡처 이미지 생성 확인
- DB 조회 결과 thumbnail_path에 캡처 이미지 경로 저장 확인
- FastAPI /api/events에서 후보 이벤트 조회 가능 확인

## 변경 파일

- .gitignore
- src/detect_ppe.py
- src/train_ppe.py
- src/helmet_event_logger.py

## 주의 사항

- runs/, test_videos/, backend/media/, detect_log.txt, *.pt 등 실행 결과물과 모델 파일은 GitHub에 올리지 않도록 제외했습니다.
- 현재 구현은 MVP 검증용으로, 영상 분석 중 안전모 미착용 후보가 발생하면 이벤트 1건을 저장하는 방식입니다.
- 추후에는 사람별 helmet bbox 매칭, 일정 시간 이상 지속 조건, 중복 이벤트 병합 로직을 추가해 정확도를 개선할 예정입니다.

## 관련 이슈

Closes #42
Closes #43
Closes #44
Closes #45
Closes #46