### PR TITLE
[FEAT] ReviewReasonCode 타입에 기타(other) 코드 추가

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,10 +8,13 @@ export type ReviewResult = 'confirmed' | 'false_positive' | 'hold';
 export type ReviewReasonCode =
   | 'confirmed_no_helmet'
   | 'confirmed_no_vest'
+  | 'confirmed_other'
   | 'false_positive_occlusion'
   | 'false_positive_angle'
+  | 'false_positive_other'
   | 'hold_unclear'
-  | 'hold_low_resolution';
+  | 'hold_low_resolution'
+  | 'hold_other';
 
 export interface CandidateEvent {
   event_id: string;


### PR DESCRIPTION
## 변경 내용

`ReviewReasonCode` 유니온 타입에 확정/오탐/보류 각각의 기타 케이스 코드 추가

### 추가된 코드값
- `confirmed_other` — 기타 (확정)
- `false_positive_other` — 기타 (오탐)
- `hold_other` — 기타 (보류)

### 변경 파일
- `frontend/src/types/index.ts`

## 관련 이슈
없음