### PR TITLE
[FEAT] 검토 판단 사유 선택지에 기타 항목 추가

### DIFF
--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -11,14 +11,17 @@ const REASON_OPTIONS: Record<ReviewResult, { value: ReviewReasonCode; label: str
   confirmed: [
     { value: 'confirmed_no_helmet', label: '안전모 미착용 확인' },
     { value: 'confirmed_no_vest', label: '안전조끼 미착용 확인' },
+    { value: 'confirmed_other', label: '기타 (확정)' },
   ],
   false_positive: [
     { value: 'false_positive_occlusion', label: '가림 현상 (오탐)' },
     { value: 'false_positive_angle', label: '촬영 각도 오류 (오탐)' },
+    { value: 'false_positive_other', label: '기타 (오탐)' },
   ],
   hold: [
     { value: 'hold_unclear', label: '영상 불명확' },
     { value: 'hold_low_resolution', label: '해상도 부족' },
+    { value: 'hold_other', label: '기타 (보류)' },
   ],
 };
 


### PR DESCRIPTION
## 변경 내용

`ReviewDetailPage`의 판단 사유 셀렉트박스에 각 검토 결과별 기타 선택지 추가

### 추가된 선택지
- 확정: `기타 (확정)`
- 오탐: `기타 (오탐)`
- 보류: `기타 (보류)`

### 변경 파일
- `frontend/src/pages/ReviewDetailPage.tsx`

## 관련 이슈
없음