### PR TITLE
[FEAT] 교육 추천 데이터 없을 때 자동 생성

### DIFF
--- a/frontend/src/pages/RecommendPage.tsx
+++ b/frontend/src/pages/RecommendPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { fetchRecommendations } from '../api/recommendations';
+import { fetchRecommendations, generateRecommendations } from '../api/recommendations';
 import type { EducationRecommendation, EducationRecommendationList } from '../types';
 import styles from './RecommendPage.module.css';
 
@@ -66,7 +66,12 @@ export default function RecommendPage() {
     setError(null);
     fetchRecommendations(quarter)
       .then(setData)
-      .catch((e) => setError(e.message))
+      .catch(() =>
+        // If no recommendations exist yet, auto-generate for the current quarter
+        generateRecommendations(quarter)
+          .then(setData)
+          .catch((e) => setError(e.message))
+      )
       .finally(() => setLoading(false));
   }, [quarter]);
 


### PR DESCRIPTION
## 변경 내용

`RecommendPage`에서 `GET /api/recommendations` 실패(데이터 없음) 시 자동으로 `POST /api/recommendations/generate`를 호출하여 교육 추천 데이터를 생성하도록 수정

### 해결된 문제
DB 초기화 후 교육 추천 페이지 접근 시 "⚠ Education recommendations not found" 에러만 표시되던 문제 해결

### 변경 파일
- `frontend/src/pages/RecommendPage.tsx`

## 관련 이슈
없음