### PR TITLE
[FEAT] 보류/2차 검토 이벤트 재검토 UI 추가

### DIFF
--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -25,3 +25,11 @@ export function submitReview(eventId: string, body: ReviewRequest): Promise<unkn
     body: JSON.stringify(body),
   });
 }
+
+// PUT endpoint — used to overwrite an existing review for hold / second_review_needed events
+export function updateReview(eventId: string, body: ReviewRequest): Promise<unknown> {
+  return apiFetch(`/api/events/${eventId}/review`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import StatusBadge from '../components/StatusBadge';
-import { fetchEvent, submitReview } from '../api/events';
+import { fetchEvent, submitReview, updateReview } from '../api/events';
 import { mediaUrl } from '../api/client';
 import type { CandidateEvent, EventReview, ReviewResult, ReviewReasonCode, ReviewRequest } from '../types';
 import styles from './ReviewDetailPage.module.css';
@@ -40,6 +40,8 @@ export default function ReviewDetailPage() {
   const [comment, setComment] = useState('');
   const [secondReview, setSecondReview] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  // True when the user clicked '재검토 시작' to overwrite an existing hold/second-review
+  const [isReReview, setIsReReview] = useState(false);
 
   useEffect(() => {
     if (!event_id) return;
@@ -86,11 +88,29 @@ export default function ReviewDetailPage() {
       second_review_needed: secondReview,
     };
     try {
-      await submitReview(event_id, body);
+      // Use PUT when overwriting an existing review (re-review flow)
+      if (isReReview) {
+        await updateReview(event_id, body);
+      } else {
+        await submitReview(event_id, body);
+      }
       setSubmitted(true);
+      setIsReReview(false);
     } catch (e: unknown) {
       setSubmitError(e instanceof Error ? e.message : '제출 중 오류가 발생했습니다.');
     }
+  };
+
+  // Unlock the form to allow re-reviewing a hold or second-review-needed event
+  const handleStartReReview = () => {
+    if (!existingReview) return;
+    setReviewResult(existingReview.review_result);
+    setReasonCode(existingReview.review_reason_code);
+    setComment(existingReview.review_comment);
+    setSecondReview(existingReview.second_review_needed);
+    setIsReReview(true);
+    setSubmitted(false);
+    setSubmitError(null);
   };
 
   return (
@@ -207,11 +227,17 @@ export default function ReviewDetailPage() {
                 <button className={styles.secondaryBtn} onClick={() => navigate('/review')}>
                   ← 목록으로
                 </button>
+                {/* Allow re-review only for hold or second-review-needed events */}
+                {existingReview && (event?.event_status === 'hold' || existingReview.second_review_needed) && (
+                  <button className={styles.primaryBtn} onClick={handleStartReReview}>
+                    🔄 재검토 시작
+                  </button>
+                )}
               </div>
             </div>
           ) : (
             <div className={styles.card}>
-              <h4 className={styles.cardTitle}>검토 입력</h4>
+              <h4 className={styles.cardTitle}>{isReReview ? '🔄 재검토 입력' : '검토 입력'}</h4>
 
               {/* Three-button toggle for review result */}
               <div className={styles.resultButtons}>


### PR DESCRIPTION
## 변경 내용

`hold` 또는 `second_review_needed=true`로 분류된 이벤트에 대해 담당자가 재검토를 제출할 수 있는 UI를 추가합니다.

### 동작 방식

1. 검토 완료된 이벤트 상세 페이지에서 `event_status === 'hold'` 또는 `second_review_needed === true`인 경우 **🔄 재검토 시작** 버튼 표시
2. 버튼 클릭 시 기존 검토값(결과, 사유, 코멘트)이 폼에 미리 채워지며 편집 가능
3. 제출 시 `PUT /api/events/{event_id}/review` 호출 (기존 검토 덮어쓰기)
4. 폼 타이틀이 **🔄 재검토 입력**으로 표시되어 재검토 중임을 명확히 안내

### 변경 파일

- `frontend/src/api/events.ts` — `updateReview()` 함수 추가 (`PUT` 호출)
- `frontend/src/pages/ReviewDetailPage.tsx` — 재검토 버튼, 폼 언락, isReReview 상태 추가

## 관련 이슈

Resolves #76

## 주의

백엔드 `PUT /api/events/{event_id}/review` 엔드포인트가 구현되기 전까지는 재검토 제출 시 오류가 발생합니다. 이슈 #76에서 @robinjh가 작업 예정입니다.