### PR TITLE
Add event re-review API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ detect_log.txt
 # Event logs / thumbnails
 events/
 backend/media/
+
+# Generated candidate event media files
+storage/candidate_events/thumbnails/*
+!storage/candidate_events/thumbnails/.gitkeep
+
+storage/candidate_events/clips/*
+!storage/candidate_events/clips/.gitkeep

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,59 +1,63 @@
-# PPE API 초기 구현
+# Backend API
 
-이 폴더는 PPE 분석 시스템의 초기 FastAPI 서버 코드를 포함함.
+이 폴더는 PPE 분석 시스템의 FastAPI 서버 코드를 포함함.
 
-현재 단계에서는 DB에 저장된 후보 이벤트를 조회하고, 담당자 검토 결과를 저장하는 최소 API를 제공함.
+현재 API는 AI가 저장한 PPE 미착용 후보 이벤트를 조회하고, 관리자의 검토 결과를 반영하며, 확정 위반 데이터를 기반으로 분기별 통계와 교육 추천을 생성하는 기능을 제공함. 또한 경고 방송 설정 관리와 후보 이벤트 미디어 파일 제공 기능을 포함함.
 
 ---
 
 ## 파일 구성
 
-| 파일 | 설명 |
-|---|---|
-| `main.py` | FastAPI 서버 및 후보 이벤트 API 엔드포인트 정의 |
-| `__init__.py` | `backend.api` 패키지 인식용 파일 |
+| 파일            | 설명                               |
+| ------------- | -------------------------------- |
+| `main.py`     | FastAPI 애플리케이션 및 API endpoint 정의 |
+| `__init__.py` | `backend.api` 패키지 인식용 파일         |
 
 ---
 
 ## 실행 전 준비
 
-API 실행 전 DB 파일이 먼저 생성되어 있어야 함.
-
-프로젝트 루트에서 아래 명령어 실행.
+API 실행 전 SQLite DB를 초기화함.
 
 ```bash
 python backend/db/init_db.py
 ```
 
-Windows 환경에서 `python` 명령어가 동작하지 않을 경우 아래 명령어 사용 가능.
+Windows 환경에서 `python` 명령어가 동작하지 않을 경우:
 
 ```bash
 py backend/db/init_db.py
+```
+
+추가 테스트 이벤트가 필요한 경우 아래 스크립트를 실행함.
+
+```bash
+python backend/db/seed_events.py
 ```
 
 ---
 
 ## API 서버 실행
 
-프로젝트 루트에서 아래 명령어 실행.
+프로젝트 루트에서 아래 명령어를 실행함.
 
 ```bash
 python -m uvicorn backend.api.main:app --reload
 ```
 
-Windows 환경에서 `python` 명령어가 동작하지 않을 경우 아래 명령어 사용 가능.
+Windows 환경에서 `python` 명령어가 동작하지 않을 경우:
 
 ```bash
 py -m uvicorn backend.api.main:app --reload
 ```
 
-정상 실행 시 아래 주소에서 API 서버 확인 가능.
+정상 실행 시 아래 주소에서 서버 상태를 확인할 수 있음.
 
 ```text
 http://127.0.0.1:8000
 ```
 
-Swagger 문서는 아래 주소에서 확인 가능.
+Swagger 문서는 아래 주소에서 확인 가능함.
 
 ```text
 http://127.0.0.1:8000/docs
@@ -63,38 +67,63 @@ http://127.0.0.1:8000/docs
 
 ## 제공 API
 
-| Method | Endpoint | 설명 |
-|---|---|---|
-| GET | `/` | API 서버 상태 확인 |
-| GET | `/api/events` | 후보 이벤트 전체 목록 조회 |
-| GET | `/api/events/{event_id}` | 후보 이벤트 단건 조회 |
-| POST | `/api/events/{event_id}/review` | 후보 이벤트 최초 검토 결과 저장 |
-| PUT | `/api/events/{event_id}/review` | 보류 또는 2차 검토 대상 이벤트 재검토 결과 갱신 |
+| Method | Endpoint                        | 설명                           |
+| ------ | ------------------------------- | ---------------------------- |
+| GET    | `/`                             | API 서버 상태 확인                 |
+| GET    | `/api/events`                   | 후보 이벤트 전체 목록 조회              |
+| GET    | `/api/events/{event_id}`        | 후보 이벤트 단건 및 검토 결과 조회         |
+| POST   | `/api/events/{event_id}/review` | 후보 이벤트 최초 검토 결과 저장           |
+| PUT    | `/api/events/{event_id}/review` | 보류 또는 2차 검토 대상 이벤트 재검토 결과 갱신 |
+| GET    | `/api/stats`                    | 생성된 분기별 통계 조회                |
+| POST   | `/api/stats/generate`           | 후보 이벤트 및 검토 결과 기반 분기별 통계 생성  |
+| GET    | `/api/recommendations`          | 생성된 교육 추천 결과 조회              |
+| POST   | `/api/recommendations/generate` | 확정 위반 데이터 기반 교육 추천 생성        |
+| GET    | `/api/broadcast/settings`       | 경고 방송 설정 조회                  |
+| PUT    | `/api/broadcast/settings`       | 경고 방송 설정 저장                  |
+
+추가로 후보 이벤트 썸네일 및 영상 참조 파일은 `/storage` 경로를 통해 정적 파일로 제공함.
 
 ---
 
-## 응답 예시
+# Events API
 
-### 후보 이벤트 전체 조회
+## 후보 이벤트 전체 목록 조회
 
-```bash
+### `GET /api/events`
+
+DB에 저장된 후보 이벤트 목록을 최신 발생 시각 순으로 조회함.
+
+현재 API는 서버 측 필터 query parameter를 제공하지 않으며, 프론트엔드 목록 화면에서 전체 이벤트를 조회한 뒤 표시 단계에서 필터링함.
+
+### 요청 예시
+
+```http
 GET /api/events
 ```
 
-응답 예시.
+### 응답 예시
 
 ```json
 {
-  "total": 3,
+  "total": 2,
   "items": [
     {
       "event_id": "EVT_0001",
       "camera_id": "CAM_001",
       "zone_name": "프레스 구역",
       "process_type": "유압 성형",
+      "tracking_id": "TRK_001",
       "ppe_type": "helmet",
+      "timestamp_start": "2026-04-28 10:15:00",
+      "timestamp_end": "2026-04-28 10:15:03",
       "duration_sec": 3,
+      "frame_sample_count": 72,
+      "thumbnail_path": "storage/candidate_events/thumbnails/EVT_0001.jpg",
+      "video_clip_path": "storage/candidate_events/clips/EVT_0001.mp4",
       "ai_confidence": 0.87,
+      "person_detected": 1,
+      "ppe_detected": 0,
+      "model_version": "helmet_yolov8n",
       "event_status": "pending"
     }
   ]
@@ -103,13 +132,19 @@ GET /api/events
 
 ---
 
-### 후보 이벤트 단건 조회
+## 후보 이벤트 단건 조회
 
-```bash
+### `GET /api/events/{event_id}`
+
+특정 후보 이벤트와 해당 이벤트의 관리자 검토 결과를 함께 조회함.
+
+### 요청 예시
+
+```http
 GET /api/events/EVT_0001
 ```
 
-응답 예시.
+### 검토 전 응답 예시
 
 ```json
 {
@@ -125,15 +160,64 @@ GET /api/events/EVT_0001
 }
 ```
 
----
+### 검토 후 응답 예시
 
-### 담당자 검토 결과 저장
-
-```bash
-POST /api/events/EVT_0001/review
+```json
+{
+  "event": {
+    "event_id": "EVT_0001",
+    "camera_id": "CAM_001",
+    "zone_name": "프레스 구역",
+    "process_type": "유압 성형",
+    "ppe_type": "helmet",
+    "event_status": "confirmed"
+  },
+  "review": {
+    "review_id": "RV_0001",
+    "event_id": "EVT_0001",
+    "reviewer_id": "admin01",
+    "review_result": "confirmed",
+    "review_reason_code": "confirmed_no_helmet",
+    "review_comment": "실제 안전모 미착용",
+    "confirmed_violation": 1,
+    "second_review_needed": 0
+  }
+}
 ```
 
-요청 Body 예시.
+존재하지 않는 이벤트를 조회하면 아래 오류를 반환함.
+
+```text
+404 Event not found
+```
+
+---
+
+# Review API
+
+관리자 검토 결과는 아래 세 가지 값 중 하나로 저장함.
+
+| `review_result`  | 의미       | 처리 방식                              |
+| ---------------- | -------- | ---------------------------------- |
+| `confirmed`      | 실제 위반 확인 | 이벤트 상태를 `confirmed`로 변경하고 검토 결과 저장 |
+| `hold`           | 판단 보류    | 이벤트 상태를 `hold`로 변경하고 검토 결과 저장      |
+| `false_positive` | 오탐       | 비식별 오탐 집계에 반영한 뒤 상세 후보 이벤트 삭제      |
+
+`false_positive`로 판단된 이벤트는 상세 이미지·이벤트 검토 데이터로 장기 보관하지 않고, 분기·구역·PPE 유형 기준의 집계값만 보존함.
+
+---
+
+## 최초 검토 결과 저장
+
+### `POST /api/events/{event_id}/review`
+
+아직 검토 결과가 저장되지 않은 후보 이벤트에 대해 최초 검토를 제출함.
+
+### 요청 예시
+
+```http
+POST /api/events/EVT_0001/review
+```
 
 ```json
 {
@@ -145,19 +229,53 @@ POST /api/events/EVT_0001/review
 }
 ```
 
-정상 저장 시 `candidate_event.event_status`가 `review_result` 값으로 갱신됨.
+### 정상 응답 예시
+
+```json
+{
+  "status": "ok",
+  "message": "Review saved successfully",
+  "event": {
+    "event_id": "EVT_0001",
+    "event_status": "confirmed"
+  },
+  "review": {
+    "review_id": "RV_0001",
+    "event_id": "EVT_0001",
+    "reviewer_id": "admin01",
+    "review_result": "confirmed",
+    "confirmed_violation": 1,
+    "second_review_needed": 0
+  }
+}
+```
+
+같은 이벤트에 대해 최초 검토를 다시 제출하면 아래 오류를 반환함.
+
+```text
+409 Review already exists
+```
 
 ---
 
-### 담당자 재검토 결과 갱신
+## 재검토 결과 갱신
 
-```bash
+### `PUT /api/events/{event_id}/review`
+
+기존 검토 결과가 있는 이벤트 중 아래 조건을 만족하는 경우에만 재검토 결과를 제출할 수 있음.
+
+| 기존 상태                                                       | 재검토 가능 여부 |
+| ----------------------------------------------------------- | --------- |
+| `event_status = hold`                                       | 가능        |
+| 기존 검토 결과의 `second_review_needed = true`                     | 가능        |
+| `event_status = confirmed`이고 `second_review_needed = false` | 불가능       |
+| 기존 검토 결과가 없는 이벤트                                            | 불가능       |
+
+### 요청 예시
+
+```http
 PUT /api/events/EVT_0001/review
 ```
-
-`hold` 상태이거나 기존 검토 결과의 `second_review_needed`가 `true`인 이벤트에 대해 재검토 결과를 제출함.
-
-요청 Body 예시.
 
 ```json
 {
@@ -169,18 +287,7 @@ PUT /api/events/EVT_0001/review
 }
 ```
 
-재검토가 허용되는 조건은 다음과 같음.
-
-| 기존 상태 | 재검토 가능 여부 |
-|---|---|
-| `event_status = hold` | 가능 |
-| 기존 검토 결과의 `second_review_needed = true` | 가능 |
-| `event_status = confirmed`이고 `second_review_needed = false` | 불가능 |
-| 기존 검토 결과가 없는 이벤트 | 불가능 |
-
-`confirmed` 또는 `hold`로 재검토한 경우 기존 `event_review` 행을 갱신하고, `candidate_event.event_status`도 재검토 결과에 맞게 갱신함.
-
-정상 응답 예시.
+### 정상 응답 예시
 
 ```json
 {
@@ -203,7 +310,9 @@ PUT /api/events/EVT_0001/review
 }
 ```
 
-재검토 결과가 `false_positive`인 경우에는 기존 오탐 처리 정책에 따라 비식별 집계에 반영한 뒤 후보 이벤트를 삭제함.
+### 오탐 재검토 응답 예시
+
+재검토 결과가 `false_positive`인 경우에는 비식별 오탐 집계에 반영한 뒤 후보 이벤트를 삭제함.
 
 ```json
 {
@@ -213,37 +322,314 @@ PUT /api/events/EVT_0001/review
   "review_result": "false_positive"
 }
 ```
+
+### 재검토 오류 응답
+
+| 상황                         | 응답                                                                  |
+| -------------------------- | ------------------------------------------------------------------- |
+| 이벤트가 존재하지 않음               | `404 Event not found`                                               |
+| 기존 검토 결과가 없음               | `409 Review does not exist`                                         |
+| 재검토 가능 조건을 만족하지 않음         | `409 Event is not eligible for re-review`                           |
+| 허용되지 않은 `review_result` 전달 | `400 review_result must be one of: confirmed, false_positive, hold` |
+
 ---
 
+# Stats API
 
-## 검토 결과 처리 기준
+## 분기별 통계 조회
 
-### 최초 검토: `POST /api/events/{event_id}/review`
+### `GET /api/stats`
 
-최초 검토 결과에 따라 후보 이벤트를 다음과 같이 처리함.
+이미 생성된 분기별 통계 데이터를 조회함.
 
-| `review_result` | 처리 방식 |
-|---|---|
-| `confirmed` | 확정 위반으로 처리하고 `candidate_event.event_status`를 `confirmed`로 갱신함 |
-| `hold` | 판단 보류 상태로 처리하고 `candidate_event.event_status`를 `hold`로 갱신함 |
-| `false_positive` | 비식별 오탐 집계에 반영한 뒤 후보 이벤트를 삭제함 |
+### Query Parameter
 
-동일 이벤트에 기존 검토 결과가 이미 존재하는 경우 최초 검토를 다시 저장할 수 없으며, `409 Review already exists`를 반환함.
+| 이름        | 기본값       | 설명                      |
+| --------- | --------- | ----------------------- |
+| `quarter` | `2026-Q2` | 조회할 분기. `YYYY-QN` 형식 사용 |
 
-### 재검토: `PUT /api/events/{event_id}/review`
+### 요청 예시
 
-재검토는 기존 이벤트가 `hold` 상태이거나, 기존 검토 결과에 `second_review_needed = true`가 저장된 경우에만 허용함.
+```http
+GET /api/stats?quarter=2026-Q2
+```
 
-| `review_result` | 처리 방식 |
-|---|---|
-| `confirmed` | 기존 `event_review`를 갱신하고 `candidate_event.event_status`를 `confirmed`로 갱신함 |
-| `hold` | 기존 `event_review`를 갱신하고 `candidate_event.event_status`를 `hold`로 갱신함 |
-| `false_positive` | 비식별 오탐 집계에 반영한 뒤 후보 이벤트를 삭제함 |
+### 응답 데이터
 
-재검토 대상이 아닌 이벤트에 PUT 요청을 보내면 `409 Event is not eligible for re-review`를 반환함.  
-기존 검토 결과가 없는 이벤트에 PUT 요청을 보내면 `409 Review does not exist`를 반환함.
+| 항목            | 설명                             |
+| ------------- | ------------------------------ |
+| `summary`     | 전체 후보 이벤트, 확정 위반, 오탐 집계, 보류 건수 |
+| `by_ppe_type` | PPE 유형별 확정 위반 건수 및 우선순위 점수     |
+| `by_zone`     | 구역별 확정 위반 건수 및 우선순위 점수         |
+| `trend`       | 분기별 안전모·안전조끼 확정 위반 추이          |
 
-## 테스트 방법
+### 응답 예시
+
+```json
+{
+  "quarter": "2026-Q2",
+  "summary": {
+    "quarter": "2026-Q2",
+    "candidate_count": 15,
+    "confirmed_count": 4,
+    "false_positive_count": 1,
+    "hold_count": 2
+  },
+  "by_ppe_type": [
+    {
+      "ppe_type": "helmet",
+      "confirmed_count": 3,
+      "priority_score": 2.0
+    }
+  ],
+  "by_zone": [
+    {
+      "zone_name": "프레스 구역",
+      "confirmed_count": 3,
+      "priority_score": 2.0
+    }
+  ],
+  "trend": [
+    {
+      "quarter": "2026-Q2",
+      "helmet": 3,
+      "vest": 1
+    }
+  ]
+}
+```
+
+생성된 통계 데이터가 없는 경우 아래 오류를 반환함.
+
+```text
+404 Quarterly stats not found
+```
+
+---
+
+## 분기별 통계 생성
+
+### `POST /api/stats/generate`
+
+후보 이벤트 및 관리자 검토 결과를 기반으로 지정 분기의 통계 데이터를 생성함.
+
+### 요청 예시
+
+```http
+POST /api/stats/generate?quarter=2026-Q2
+```
+
+### 생성 기준
+
+| 데이터         | 반영 기준                               |
+| ----------- | ----------------------------------- |
+| 후보 이벤트 수    | 지정 분기에 발생한 `candidate_event` 건수     |
+| 확정 위반 수     | `event_status = confirmed`인 이벤트 수   |
+| 보류 수        | `event_status = hold`인 이벤트 수        |
+| 오탐 수        | `false_positive_aggregate`의 비식별 집계값 |
+| PPE·구역 우선순위 | 확정 위반 건수, 반복 발생 주차, 집중도 기준 계산       |
+
+생성된 통계 데이터는 동일 응답 구조로 반환됨.
+
+---
+
+# Recommendations API
+
+## 교육 추천 결과 조회
+
+### `GET /api/recommendations`
+
+이미 생성된 분기별 교육 추천 결과를 조회함.
+
+### 요청 예시
+
+```http
+GET /api/recommendations?quarter=2026-Q2
+```
+
+### 응답 예시
+
+```json
+{
+  "quarter": "2026-Q2",
+  "generated_at": "2026-05-28 18:00:00",
+  "items": [
+    {
+      "recommendation_id": "EDU_2026Q2_01",
+      "recommendation_rank": 1,
+      "ppe_type": "helmet",
+      "zone_name": "프레스 구역",
+      "education_topic": "프레스 구역 안전모 착용 기준 및 착용 전 점검 절차 교육",
+      "priority_score": 2.0,
+      "score_breakdown": {
+        "confirmed_count": 3,
+        "repeat_weeks": 2,
+        "zone_concentration": 0.75,
+        "process_risk_weight": 1.0
+      },
+      "generated_at": "2026-05-28 18:00:00"
+    }
+  ]
+}
+```
+
+생성된 교육 추천 데이터가 없는 경우 아래 오류를 반환함.
+
+```text
+404 Education recommendations not found
+```
+
+---
+
+## 교육 추천 생성
+
+### `POST /api/recommendations/generate`
+
+관리자가 `confirmed`로 확정한 실제 위반 데이터를 기반으로 교육 추천 결과를 생성함.
+
+### 요청 예시
+
+```http
+POST /api/recommendations/generate?quarter=2026-Q2
+```
+
+### 생성 기준
+
+교육 추천은 아래 요소를 기준으로 PPE 유형·구역별 우선순위를 계산하고, 상위 추천 항목을 생성함.
+
+| 기준                    | 설명                           |
+| --------------------- | ---------------------------- |
+| `confirmed_count`     | 해당 PPE 유형·구역에서 확정된 위반 건수     |
+| `repeat_weeks`        | 확정 위반이 발생한 주차 수              |
+| `zone_concentration`  | 전체 확정 위반 중 해당 유형·구역이 차지하는 비율 |
+| `process_risk_weight` | 공정 위험도 가중치                   |
+
+현재 직접 생성되는 교육 주제 예시는 다음과 같음.
+
+| PPE 유형   | 교육 주제 예시                                |
+| -------- | --------------------------------------- |
+| `helmet` | 프레스 구역 안전모 착용 기준 및 착용 전 점검 절차 교육        |
+| `vest`   | 자재 이동 구역 안전조끼 착용 필요성과 작업 구역 내 시인성 확보 교육 |
+
+확정 위반 이벤트가 없어 추천 항목을 생성할 수 없는 경우 아래 오류를 반환함.
+
+```text
+404 No confirmed events found for recommendation generation
+```
+
+---
+
+# Broadcast Settings API
+
+## 경고 방송 설정 조회
+
+### `GET /api/broadcast/settings`
+
+경고 방송 실행 서비스에서 사용하는 현재 설정을 조회함.
+
+### 응답 예시
+
+```json
+{
+  "enabled": true,
+  "default_language": "ko",
+  "cooldown_sec": 30,
+  "templates": [
+    {
+      "ppe_type": "helmet",
+      "zone_name": "",
+      "language": "ko",
+      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
+    }
+  ]
+}
+```
+
+### 설정 항목
+
+| 항목                 | 설명                       |
+| ------------------ | ------------------------ |
+| `enabled`          | 경고 방송 전체 사용 여부           |
+| `default_language` | 기본 방송 언어                 |
+| `cooldown_sec`     | 동일 상황 반복 방송 제한 시간        |
+| `templates`        | PPE 유형·구역·언어별 메시지 템플릿 목록 |
+
+---
+
+## 경고 방송 설정 저장
+
+### `PUT /api/broadcast/settings`
+
+경고 방송 설정과 메시지 템플릿 목록을 저장함.
+
+### 요청 예시
+
+```http
+PUT /api/broadcast/settings
+```
+
+```json
+{
+  "enabled": true,
+  "default_language": "ko",
+  "cooldown_sec": 30,
+  "templates": [
+    {
+      "ppe_type": "helmet",
+      "zone_name": "프레스 구역",
+      "language": "ko",
+      "message": "프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요."
+    },
+    {
+      "ppe_type": "helmet",
+      "zone_name": "",
+      "language": "en",
+      "message": "Workers in this area, please check your helmet."
+    }
+  ]
+}
+```
+
+저장 완료 후에는 저장된 설정값을 다시 조회하여 응답으로 반환함.
+
+실제 경고 메시지 선택, cooldown 처리, 터미널 로그 출력 및 TTS 음성 출력은 `backend/services/warning_broadcast_service.py`에서 수행함.
+
+---
+
+# Static Media
+
+후보 이벤트 검토용 썸네일과 영상 참조 파일은 `storage` 디렉터리 아래에 저장되며, FastAPI는 `/storage` 경로를 정적 파일 경로로 제공함.
+
+## 저장 경로
+
+| 경로                                    | 설명                    |
+| ------------------------------------- | --------------------- |
+| `storage/candidate_events/thumbnails` | 후보 이벤트 썸네일 이미지        |
+| `storage/candidate_events/clips`      | 후보 이벤트 영상 클립 또는 참조 영상 |
+
+## 접근 예시
+
+프로젝트 내 저장 경로:
+
+```text
+storage/candidate_events/thumbnails/EVT_20260519160059_b95d63.jpg
+```
+
+브라우저 또는 프론트엔드 접근 URL:
+
+```text
+http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_20260519160059_b95d63.jpg
+```
+
+파일이 존재하면 `200`으로 반환하고, 존재하지 않으면 `404`를 반환함.
+
+생성되는 이미지와 영상 파일은 로컬 실행 산출물이므로 Git에 포함하지 않고, 디렉터리 유지를 위한 `.gitkeep`만 관리함.
+
+---
+
+# 테스트 방법
+
+## API 기본 흐름 확인
 
 1. DB 초기화
 
@@ -251,303 +637,115 @@ PUT /api/events/EVT_0001/review
 python backend/db/init_db.py
 ```
 
-2. API 서버 실행
+2. 필요 시 테스트 이벤트 추가
+
+```bash
+python backend/db/seed_events.py
+```
+
+3. 서버 실행
 
 ```bash
 python -m uvicorn backend.api.main:app --reload
 ```
 
-3. Swagger 접속
+4. Swagger 접속
 
 ```text
 http://127.0.0.1:8000/docs
 ```
 
-4. 아래 API 순서대로 테스트
+---
+
+## 최초 검토 및 재검토 확인
+
+아래 순서로 실행함.
 
 ```text
-GET /api/events
-GET /api/events/{event_id}
-POST /api/events/{event_id}/review
-GET /api/events/{event_id}
+GET  /api/events
+POST /api/events/EVT_0001/review       # review_result = hold
+PUT  /api/events/EVT_0001/review       # review_result = confirmed
+GET  /api/events/EVT_0001
 ```
 
-마지막 `GET /api/events/{event_id}`에서 `review` 값이 추가되고, `event_status`가 변경되면 정상 동작임.
+정상 동작 시 아래를 확인할 수 있음.
 
-### 재검토 API 테스트
-
-1. 최초 검토 결과를 `hold`로 저장함.
-
-```http
-POST /api/events/EVT_0001/review
-```
-
-```json
-{
-  "reviewer_id": "admin01",
-  "review_result": "hold",
-  "review_reason_code": "needs_additional_check",
-  "review_comment": "영상 확인 필요",
-  "second_review_needed": false
-}
-```
-
-2. 동일 이벤트를 `confirmed`로 재검토함.
-
-```http
-PUT /api/events/EVT_0001/review
-```
-
-```json
-{
-  "reviewer_id": "admin02",
-  "review_result": "confirmed",
-  "review_reason_code": "confirmed_no_helmet",
-  "review_comment": "재검토 결과 실제 위반 확인",
-  "second_review_needed": false
-}
-```
-
-3. 단건 조회 API로 갱신 결과를 확인함.
-
-```http
-GET /api/events/EVT_0001
-```
-
-정상 동작 시 아래 항목을 확인할 수 있음.
-
-- `event.event_status`가 `confirmed`로 변경됨
-- `review.reviewer_id`가 재검토 담당자 값으로 변경됨
-- `review.review_result`가 `confirmed`로 변경됨
-- `review.confirmed_violation`이 `1`로 변경됨
-
-추가 확인 항목:
-
-- `confirmed`이면서 `second_review_needed = false`인 이벤트의 재검토 요청은 `409`를 반환함
-- 기존 검토 결과가 없는 이벤트의 재검토 요청은 `409`를 반환함
-- `hold` 이벤트를 `false_positive`로 재검토하면 이벤트가 삭제됨
+* 최초 검토 이후 이벤트 상태가 `hold`로 변경됨
+* 재검토 이후 이벤트 상태가 `confirmed`로 변경됨
+* 검토 담당자 및 검토 결과가 재검토 요청값으로 갱신됨
 
 ---
 
-## 분기별 통계 조회 API
+## 통계 및 교육 추천 확인
 
-### `GET /api/stats`
+먼저 후보 이벤트 중 일부를 `confirmed`로 검토한 후 아래 순서로 실행함.
 
-분기별 통계 데이터를 조회함.
+```text
+POST /api/stats/generate?quarter=2026-Q2
+GET  /api/stats?quarter=2026-Q2
 
-예시:
-
-```http
-GET /api/stats?quarter=2026-Q2
+POST /api/recommendations/generate?quarter=2026-Q2
+GET  /api/recommendations?quarter=2026-Q2
 ```
 
-응답에는 다음 데이터가 포함됨.
-
-- 분기 요약 통계
-- PPE 유형별 확정 위반 수 및 우선순위 점수
-- 구역별 확정 위반 수 및 우선순위 점수
-- 최근 분기별 helmet/vest 위반 추이
-
-응답 예시:
-
-```json
-{
-  "quarter": "2026-Q2",
-  "summary": {
-    "quarter": "2026-Q2",
-    "candidate_count": 145,
-    "confirmed_count": 98,
-    "false_positive_count": 32,
-    "hold_count": 15
-  },
-  "by_ppe_type": [
-    {
-      "ppe_type": "helmet",
-      "confirmed_count": 60,
-      "priority_score": 8.6
-    },
-    {
-      "ppe_type": "vest",
-      "confirmed_count": 38,
-      "priority_score": 5.2
-    }
-  ],
-  "by_zone": [
-    {
-      "zone_name": "프레스 구역",
-      "confirmed_count": 45,
-      "priority_score": 8.6
-    }
-  ],
-  "trend": [
-    {
-      "quarter": "2025-Q3",
-      "helmet": 40,
-      "vest": 25
-    }
-  ]
-}
-```
+정상 동작 시 확정 위반 건수를 기반으로 분기별 통계와 교육 추천 결과를 확인할 수 있음.
 
 ---
 
-## 교육 추천 조회 API
+## 방송 설정 확인
 
-### `GET /api/recommendations`
-
-분기별 교육 추천 데이터를 조회함.
-
-예시:
-
-```http
-GET /api/recommendations?quarter=2026-Q2
-```
-
-응답에는 다음 데이터가 포함됨.
-
-- 추천 순위
-- PPE 유형
-- 발생 구역
-- 교육 주제
-- 우선순위 점수
-- 점수 산정 근거
-
-응답 예시:
-
-```json
-{
-  "quarter": "2026-Q2",
-  "generated_at": "2026-06-30 18:00:00",
-  "items": [
-    {
-      "recommendation_id": "EDU_2026Q2_01",
-      "recommendation_rank": 1,
-      "ppe_type": "helmet",
-      "zone_name": "프레스 구역",
-      "education_topic": "안전모 착용 기준 및 착용 전 점검 절차 교육",
-      "priority_score": 8.6,
-      "score_breakdown": {
-        "confirmed_count": 60,
-        "repeat_weeks": 5,
-        "zone_concentration": 0.61,
-        "process_risk_weight": 1.0
-      },
-      "generated_at": "2026-06-30 18:00:00"
-    }
-  ]
-}
-```
-
----
-
-## 참고 사항
-
-현재 `/api/stats`와 `/api/recommendations`는 프론트엔드 Mock 데이터 구조와 유사한 형태로 응답하도록 구성함.
-
-`false_positive_count`는 오탐 이벤트 상세 기록을 장기 보관하지 않고, `false_positive_aggregate`에 저장된 비식별 집계값을 기준으로 계산함.
-
-이번 단계에서는 분기별 통계 및 교육 추천 더미 데이터를 DB에 저장하고 조회하는 구조를 우선 구현함. 실제 후보 이벤트와 담당자 검토 결과를 기반으로 통계를 자동 계산하고 교육 추천을 생성하는 로직은 이후 단계에서 확장 예정임.
-
----
-
-## 경고 방송 설정 API
-
-### `GET /api/broadcast/settings`
-
-경고 방송 설정을 조회함.
-
-예시:
-
-```http
+```text
+GET /api/broadcast/settings
+PUT /api/broadcast/settings
 GET /api/broadcast/settings
 ```
 
-응답 예시:
-
-```json
-{
-  "enabled": true,
-  "default_language": "ko",
-  "cooldown_sec": 30,
-  "templates": [
-    {
-      "ppe_type": "helmet",
-      "zone_name": "",
-      "language": "ko",
-      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
-    }
-  ]
-}
-```
+저장 이후 다시 조회했을 때 `enabled`, `default_language`, `cooldown_sec`, `templates` 값이 전달한 요청과 일치하면 정상 동작임.
 
 ---
 
-### `PUT /api/broadcast/settings`
+## 정적 미디어 확인
 
-경고 방송 설정을 저장함.
+서버 실행 후 PowerShell에서 아래 명령어를 실행함.
 
-예시:
-
-```http
-PUT /api/broadcast/settings
+```powershell
+curl.exe -o NUL -w "%{http_code}`n" http://127.0.0.1:8000/storage/candidate_events/thumbnails/nonexistent.jpg
 ```
 
-요청 Body 예시:
+없는 파일에 대해 `404`가 반환되면 정적 경로가 정상 등록된 상태임.
 
-```json
-{
-  "enabled": true,
-  "default_language": "ko",
-  "cooldown_sec": 30,
-  "templates": [
-    {
-      "ppe_type": "helmet",
-      "zone_name": "",
-      "language": "ko",
-      "message": "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
-    }
-  ]
-}
-```
-
-응답은 저장된 설정을 다시 반환함.
+실제 썸네일 파일이 존재하는 경우 해당 파일명으로 다시 호출하여 `200` 응답을 확인할 수 있음.
 
 ---
 
-## 정적 미디어 파일 제공
+# 현재 구현 범위 및 후속 확장
 
-후보 이벤트 검토용 썸네일과 영상 클립은 `storage` 디렉터리 아래에 저장되며, FastAPI에서 `/storage` 경로로 정적 파일을 제공함.
+## 현재 구현 범위
 
-예시 파일 경로:
+* 후보 이벤트 전체 목록 및 단건 조회
+* 관리자 최초 검토 및 재검토 처리
+* 오탐 이벤트 비식별 집계 후 상세 삭제 처리
+* 확정 위반 데이터 기반 분기별 통계 생성 및 조회
+* 확정 위반 데이터 기반 교육 추천 생성 및 조회
+* 경고 방송 설정 조회 및 저장
+* 후보 이벤트 썸네일·영상 참조 파일 정적 제공
 
-```text
-storage/candidate_events/thumbnails/EVT_xxxx.jpg
-```
+## 후속 확장 대상
 
-브라우저 접근 URL:
-
-```text
-http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_xxxx.jpg
-```
-
-없는 파일에 접근하면 404를 반환하고, 실제 파일이 존재하면 200으로 파일을 반환함.
-
-이 경로는 프론트엔드 ReviewDetailPage에서 후보 이벤트의 `thumbnail_path`, `video_clip_path`를 표시할 때 사용함.
-
-## 참고 사항
-
-이 API는 경고 방송 설정을 저장하고 조회하기 위한 API임.
-
-실제 경고 방송 실행, 터미널 출력, TTS 음성 출력은 별도 기능에서 구현함.
+* AI 탐지 코드와 후보 이벤트 생성 서비스의 실제 연동
+* 안전조끼 미착용 이벤트 생성 흐름 연결
+* 이벤트 구간 기준 실제 짧은 영상 클립 생성
+* 서버 측 후보 이벤트 필터링 및 페이지네이션
+* 방송 실행 이력 저장 및 조회
+* 지속 가능한 cooldown 상태 관리
 
 ---
 
 ## 주의 사항
 
-- 같은 이벤트에 대해 `POST /api/events/{event_id}/review`를 두 번 호출하면 `409 Review already exists` 응답을 반환함.
-- 기존 검토 결과가 있는 이벤트라도 `hold` 상태이거나 `second_review_needed = true`인 경우에는 `PUT /api/events/{event_id}/review`로 재검토 가능함.
-- 재검토 대상이 아닌 이벤트에 PUT 요청을 보내면 `409 Event is not eligible for re-review` 응답을 반환함.
-- 존재하지 않는 이벤트 ID를 조회하거나 검토 결과를 저장하면 `404 Event not found` 응답을 반환함.
-- `review_result`는 `confirmed`, `false_positive`, `hold` 중 하나만 허용함.
-- `false_positive`로 처리된 이벤트는 비식별 오탐 집계에 반영된 후 상세 후보 이벤트에서 삭제됨.
-- 로컬 DB 파일 `ppe_system.db`는 GitHub에 업로드하지 않음.
+* 같은 이벤트에 대해 `POST /api/events/{event_id}/review`를 두 번 호출하면 `409 Review already exists`를 반환함.
+* 재검토는 `hold` 상태이거나 기존 검토 결과의 `second_review_needed = true`인 이벤트에 대해서만 가능함.
+* `false_positive`로 처리된 후보 이벤트는 비식별 오탐 집계에 반영된 후 상세 이벤트에서 삭제됨.
+* 통계 및 교육 추천은 별도의 생성 API를 호출한 후 조회 가능함.
+* 현재 후보 이벤트 목록의 화면 필터링은 프론트엔드에서 수행하며, 서버 측 filter query parameter는 후속 확장 범위임.
+* 로컬 DB 파일과 생성된 썸네일·영상 파일은 Git에 포함하지 않음.

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -68,7 +68,8 @@ http://127.0.0.1:8000/docs
 | GET | `/` | API 서버 상태 확인 |
 | GET | `/api/events` | 후보 이벤트 전체 목록 조회 |
 | GET | `/api/events/{event_id}` | 후보 이벤트 단건 조회 |
-| POST | `/api/events/{event_id}/review` | 후보 이벤트 담당자 검토 결과 저장 |
+| POST | `/api/events/{event_id}/review` | 후보 이벤트 최초 검토 결과 저장 |
+| PUT | `/api/events/{event_id}/review` | 보류 또는 2차 검토 대상 이벤트 재검토 결과 갱신 |
 
 ---
 
@@ -148,29 +149,99 @@ POST /api/events/EVT_0001/review
 
 ---
 
+### 담당자 재검토 결과 갱신
+
+```bash
+PUT /api/events/EVT_0001/review
+```
+
+`hold` 상태이거나 기존 검토 결과의 `second_review_needed`가 `true`인 이벤트에 대해 재검토 결과를 제출함.
+
+요청 Body 예시.
+
+```json
+{
+  "reviewer_id": "admin02",
+  "review_result": "confirmed",
+  "review_reason_code": "confirmed_no_helmet",
+  "review_comment": "재검토 결과 실제 위반 확인",
+  "second_review_needed": false
+}
+```
+
+재검토가 허용되는 조건은 다음과 같음.
+
+| 기존 상태 | 재검토 가능 여부 |
+|---|---|
+| `event_status = hold` | 가능 |
+| 기존 검토 결과의 `second_review_needed = true` | 가능 |
+| `event_status = confirmed`이고 `second_review_needed = false` | 불가능 |
+| 기존 검토 결과가 없는 이벤트 | 불가능 |
+
+`confirmed` 또는 `hold`로 재검토한 경우 기존 `event_review` 행을 갱신하고, `candidate_event.event_status`도 재검토 결과에 맞게 갱신함.
+
+정상 응답 예시.
+
+```json
+{
+  "status": "ok",
+  "message": "Review updated successfully",
+  "event": {
+    "event_id": "EVT_0001",
+    "event_status": "confirmed"
+  },
+  "review": {
+    "review_id": "RV_0001",
+    "event_id": "EVT_0001",
+    "reviewer_id": "admin02",
+    "review_result": "confirmed",
+    "review_reason_code": "confirmed_no_helmet",
+    "review_comment": "재검토 결과 실제 위반 확인",
+    "confirmed_violation": 1,
+    "second_review_needed": 0
+  }
+}
+```
+
+재검토 결과가 `false_positive`인 경우에는 기존 오탐 처리 정책에 따라 비식별 집계에 반영한 뒤 후보 이벤트를 삭제함.
+
+```json
+{
+  "status": "ok",
+  "message": "False positive event deleted after re-review",
+  "event_id": "EVT_0001",
+  "review_result": "false_positive"
+}
+```
+---
+
+
 ## 검토 결과 처리 기준
 
-`POST /api/events/{event_id}/review` API는 담당자 검토 결과에 따라 후보 이벤트를 다르게 처리함.
+### 최초 검토: `POST /api/events/{event_id}/review`
 
-| review_result | 처리 방식 |
+최초 검토 결과에 따라 후보 이벤트를 다음과 같이 처리함.
+
+| `review_result` | 처리 방식 |
 |---|---|
 | `confirmed` | 확정 위반으로 처리하고 `candidate_event.event_status`를 `confirmed`로 갱신함 |
 | `hold` | 판단 보류 상태로 처리하고 `candidate_event.event_status`를 `hold`로 갱신함 |
-| `false_positive` | 오탐으로 판단하여 후보 이벤트를 삭제함 |
+| `false_positive` | 비식별 오탐 집계에 반영한 뒤 후보 이벤트를 삭제함 |
 
-오탐으로 판단된 이벤트는 장기 보관하지 않으며, 추후 필요한 경우 비식별 집계 수준의 오탐 수만 모델 개선 지표로 활용할 수 있음.
+동일 이벤트에 기존 검토 결과가 이미 존재하는 경우 최초 검토를 다시 저장할 수 없으며, `409 Review already exists`를 반환함.
 
----
+### 재검토: `PUT /api/events/{event_id}/review`
 
-## review_result 값 기준
+재검토는 기존 이벤트가 `hold` 상태이거나, 기존 검토 결과에 `second_review_needed = true`가 저장된 경우에만 허용함.
 
-| 값 | 의미 |
+| `review_result` | 처리 방식 |
 |---|---|
-| `confirmed` | 확정 위반 |
-| `false_positive` | 오탐 |
-| `hold` | 판단 보류 |
+| `confirmed` | 기존 `event_review`를 갱신하고 `candidate_event.event_status`를 `confirmed`로 갱신함 |
+| `hold` | 기존 `event_review`를 갱신하고 `candidate_event.event_status`를 `hold`로 갱신함 |
+| `false_positive` | 비식별 오탐 집계에 반영한 뒤 후보 이벤트를 삭제함 |
 
----
+재검토 대상이 아닌 이벤트에 PUT 요청을 보내면 `409 Event is not eligible for re-review`를 반환함.  
+기존 검토 결과가 없는 이벤트에 PUT 요청을 보내면 `409 Review does not exist`를 반환함.
 
 ## 테스트 방법
 
@@ -202,6 +273,59 @@ GET /api/events/{event_id}
 ```
 
 마지막 `GET /api/events/{event_id}`에서 `review` 값이 추가되고, `event_status`가 변경되면 정상 동작임.
+
+### 재검토 API 테스트
+
+1. 최초 검토 결과를 `hold`로 저장함.
+
+```http
+POST /api/events/EVT_0001/review
+```
+
+```json
+{
+  "reviewer_id": "admin01",
+  "review_result": "hold",
+  "review_reason_code": "needs_additional_check",
+  "review_comment": "영상 확인 필요",
+  "second_review_needed": false
+}
+```
+
+2. 동일 이벤트를 `confirmed`로 재검토함.
+
+```http
+PUT /api/events/EVT_0001/review
+```
+
+```json
+{
+  "reviewer_id": "admin02",
+  "review_result": "confirmed",
+  "review_reason_code": "confirmed_no_helmet",
+  "review_comment": "재검토 결과 실제 위반 확인",
+  "second_review_needed": false
+}
+```
+
+3. 단건 조회 API로 갱신 결과를 확인함.
+
+```http
+GET /api/events/EVT_0001
+```
+
+정상 동작 시 아래 항목을 확인할 수 있음.
+
+- `event.event_status`가 `confirmed`로 변경됨
+- `review.reviewer_id`가 재검토 담당자 값으로 변경됨
+- `review.review_result`가 `confirmed`로 변경됨
+- `review.confirmed_violation`이 `1`로 변경됨
+
+추가 확인 항목:
+
+- `confirmed`이면서 `second_review_needed = false`인 이벤트의 재검토 요청은 `409`를 반환함
+- 기존 검토 결과가 없는 이벤트의 재검토 요청은 `409`를 반환함
+- `hold` 이벤트를 `false_positive`로 재검토하면 이벤트가 삭제됨
 
 ---
 
@@ -420,7 +544,10 @@ http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_xxxx.jpg
 
 ## 주의 사항
 
-- 같은 이벤트에 대해 검토 결과를 두 번 저장하면 `409 Review already exists` 응답 반환.
-- 존재하지 않는 이벤트 ID를 조회하거나 검토 결과를 저장하면 `404 Event not found` 응답 반환.
+- 같은 이벤트에 대해 `POST /api/events/{event_id}/review`를 두 번 호출하면 `409 Review already exists` 응답을 반환함.
+- 기존 검토 결과가 있는 이벤트라도 `hold` 상태이거나 `second_review_needed = true`인 경우에는 `PUT /api/events/{event_id}/review`로 재검토 가능함.
+- 재검토 대상이 아닌 이벤트에 PUT 요청을 보내면 `409 Event is not eligible for re-review` 응답을 반환함.
+- 존재하지 않는 이벤트 ID를 조회하거나 검토 결과를 저장하면 `404 Event not found` 응답을 반환함.
 - `review_result`는 `confirmed`, `false_positive`, `hold` 중 하나만 허용함.
+- `false_positive`로 처리된 이벤트는 비식별 오탐 집계에 반영된 후 상세 후보 이벤트에서 삭제됨.
 - 로컬 DB 파일 `ppe_system.db`는 GitHub에 업로드하지 않음.

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -20,6 +20,7 @@ from backend.db.event_repository import (
     get_candidate_event_by_id,
     get_review_by_event_id,
     insert_event_review,
+    update_event_review,
     get_quarterly_stats,
     get_education_recommendations,
     generate_quarterly_stats,
@@ -206,6 +207,84 @@ def create_event_review(event_id: str, request: ReviewRequest) -> dict:
         "message": "Review saved successfully",
         "event": updated_event,
         "review": saved_review,
+    }
+
+@app.put("/api/events/{event_id}/review")
+def update_existing_event_review(event_id: str, request: ReviewRequest) -> dict:
+    """
+    보류 또는 2차 검토 대상 이벤트의 기존 검토 결과를 갱신함.
+
+    Args:
+        event_id (str):
+            재검토 대상 후보 이벤트 ID.
+        request (ReviewRequest):
+            재검토 결과 요청 데이터.
+
+    Returns:
+        dict:
+            갱신된 검토 결과와 후보 이벤트 정보.
+            false_positive인 경우 삭제 처리 결과 반환.
+    """
+    event = get_candidate_event_by_id(event_id)
+
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if request.review_result not in {"confirmed", "false_positive", "hold"}:
+        raise HTTPException(
+            status_code=400,
+            detail="review_result must be one of: confirmed, false_positive, hold",
+        )
+
+    existing_review = get_review_by_event_id(event_id)
+
+    if existing_review is None:
+        raise HTTPException(status_code=409, detail="Review does not exist")
+
+    is_hold_event = event["event_status"] == "hold"
+    needs_second_review = existing_review["second_review_needed"] == 1
+
+    if not is_hold_event and not needs_second_review:
+        raise HTTPException(
+            status_code=409,
+            detail="Event is not eligible for re-review",
+        )
+
+    confirmed_violation = 1 if request.review_result == "confirmed" else 0
+
+    review = {
+        "review_id": existing_review["review_id"],
+        "event_id": event_id,
+        "reviewer_id": request.reviewer_id,
+        "review_result": request.review_result,
+        "review_reason_code": request.review_reason_code,
+        "review_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "review_comment": request.review_comment,
+        "confirmed_violation": confirmed_violation,
+        "second_review_needed": 1 if request.second_review_needed else 0,
+    }
+
+    try:
+        update_event_review(review)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    if request.review_result == "false_positive":
+        return {
+            "status": "ok",
+            "message": "False positive event deleted after re-review",
+            "event_id": event_id,
+            "review_result": request.review_result,
+        }
+
+    updated_event = get_candidate_event_by_id(event_id)
+    updated_review = get_review_by_event_id(event_id)
+
+    return {
+        "status": "ok",
+        "message": "Review updated successfully",
+        "event": updated_event,
+        "review": updated_review,
     }
 
 @app.get("/api/stats")

--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -1,199 +1,508 @@
-# PPE DB 초기 구축
+# Backend Database
 
-이 폴더는 PPE 분석 시스템의 초기 SQLite DB 구조와 테스트용 DB 접근 코드를 포함한다.
+이 폴더는 PPE 분석 시스템의 SQLite 데이터베이스 구조와 DB 접근 계층 코드를 포함함.
 
-현재 단계에서는 전체 백엔드 서버를 구현하기 전, 후보 이벤트 저장 구조와 담당자 검토 결과 저장 흐름을 먼저 검증하는 것을 목적으로 한다.
+현재 DB는 AI가 생성한 PPE 미착용 후보 이벤트를 저장하고, 관리자 검토 및 재검토 결과를 반영하며, 확정 위반 데이터를 기반으로 통계와 교육 추천을 생성하는 흐름을 지원함. 또한 경고 방송 설정과 메시지 템플릿을 저장하여 방송 실행 서비스에서 사용할 수 있도록 구성함.
 
 ---
 
 ## 파일 구성
 
-| 파일 | 설명 |
-|---|---|
-| `schema.sql` | DB 테이블 생성 SQL |
-| `seed.sql` | 초기 테스트용 더미 데이터 |
-| `init_db.py` | SQLite DB 생성 및 초기화 스크립트 |
-| `check_db.py` | DB 테이블 및 더미 데이터 조회 확인 스크립트 |
-| `event_repository.py` | 후보 이벤트 및 검토 결과 DB 접근 함수 |
-| `test_event_repository.py` | repository 함수 동작 확인용 테스트 스크립트 |
+| 파일                         | 설명                                 |
+| -------------------------- | ---------------------------------- |
+| `schema.sql`               | DB 테이블 생성 SQL                      |
+| `seed.sql`                 | 기본 테스트용 초기 데이터 삽입 SQL              |
+| `init_db.py`               | SQLite DB 생성 및 초기화 스크립트            |
+| `seed_events.py`           | 추가 테스트용 후보 이벤트 삽입 스크립트             |
+| `check_db.py`              | DB 테이블 및 저장 데이터 조회 확인 스크립트         |
+| `event_repository.py`      | 후보 이벤트, 검토, 통계, 추천, 방송 설정 DB 접근 함수 |
+| `test_event_repository.py` | repository 함수 동작 확인용 테스트 스크립트      |
 
 ---
 
 ## 생성되는 DB 파일
 
-`init_db.py`를 실행하면 아래 DB 파일이 생성된다.
+`init_db.py`를 실행하면 아래 위치에 SQLite DB 파일이 생성됨.
 
 ```text
 backend/db/ppe_system.db
 ```
 
-해당 파일은 로컬 실행 시 생성되는 파일이므로 GitHub에는 업로드하지 않는다.  
-`.gitignore`에서 `backend/db/*.db` 규칙으로 제외한다.
+해당 파일은 로컬 실행 및 테스트 과정에서 생성되는 런타임 데이터이므로 Git에 포함하지 않음.
+
+```gitignore
+backend/db/*.db
+```
 
 ---
 
-## 실행 순서
+## DB 초기화 및 확인
 
-프로젝트 루트에서 아래 명령어를 실행한다.
+프로젝트 루트에서 아래 순서로 실행함.
 
 ```bash
 python backend/db/init_db.py
 python backend/db/check_db.py
-python backend/db/test_event_repository.py
 ```
 
-Windows 환경에서 `python` 명령어가 동작하지 않으면 다음 명령어를 사용한다.
+Windows 환경에서 `python` 명령어가 동작하지 않을 경우:
 
 ```bash
 py backend/db/init_db.py
 py backend/db/check_db.py
-py backend/db/test_event_repository.py
+```
+
+추가 테스트용 후보 이벤트가 필요한 경우 아래 스크립트를 실행함.
+
+```bash
+python backend/db/seed_events.py
 ```
 
 ---
 
-## 실행 결과 확인 기준
+## 데이터 처리 흐름
 
-### 1. DB 초기화
+현재 DB는 아래 흐름을 기준으로 사용됨.
+
+```text
+AI PPE 미착용 탐지
+→ candidate_event 후보 이벤트 저장
+→ 관리자 최초 검토 또는 재검토
+→ confirmed / hold / false_positive 결과 반영
+→ confirmed 데이터 기반 통계 생성
+→ confirmed 데이터 기반 교육 추천 생성
+```
+
+경고 방송 설정은 별도 흐름으로 저장되며, 후보 이벤트 생성 이후 방송 실행 서비스가 해당 설정을 조회하여 사용함.
+
+```text
+방송 설정 UI
+→ broadcast_setting 및 broadcast_message_template 저장
+→ 후보 이벤트 발생
+→ 방송 실행 서비스가 설정 조회
+→ 메시지 선택 및 TTS 실행
+```
+
+---
+
+# 테이블 구성
+
+## 1. 이벤트 및 검토 테이블
+
+| 테이블                        | 역할                        |
+| -------------------------- | ------------------------- |
+| `camera_info`              | 카메라 ID, 촬영 구역, 공정 정보 저장   |
+| `candidate_event`          | AI가 생성한 PPE 미착용 후보 이벤트 저장 |
+| `event_review`             | 관리자의 확정 위반·보류 검토 결과 저장    |
+| `false_positive_aggregate` | 오탐 이벤트의 비식별 집계값 저장        |
+
+---
+
+## 2. 통계 및 교육 추천 테이블
+
+| 테이블                        | 역할                              |
+| -------------------------- | ------------------------------- |
+| `quarterly_summary`        | 분기별 후보 이벤트, 확정 위반, 오탐, 보류 건수 요약 |
+| `quarterly_ppe_stats`      | PPE 유형별 확정 위반 수 및 우선순위 점수 저장    |
+| `quarterly_zone_stats`     | 구역별 확정 위반 수 및 우선순위 점수 저장        |
+| `quarterly_trend_stats`    | 분기별 안전모·안전조끼 확정 위반 추이 저장        |
+| `education_recommendation` | 분기별 교육 추천 결과와 점수 산정 근거 저장       |
+
+---
+
+## 3. 경고 방송 설정 테이블
+
+| 테이블                          | 역할                              |
+| ---------------------------- | ------------------------------- |
+| `broadcast_setting`          | 방송 사용 여부, 기본 언어, cooldown 설정 저장 |
+| `broadcast_message_template` | PPE 유형·구역·언어별 방송 메시지 템플릿 저장     |
+
+---
+
+# 주요 데이터 구조
+
+## `camera_info`
+
+후보 이벤트가 발생한 구역 및 공정 정보를 연결하기 위한 기준 테이블임.
+
+주요 데이터 예시:
+
+| 필드             | 설명      |
+| -------------- | ------- |
+| `camera_id`    | 카메라 식별자 |
+| `zone_name`    | 작업 구역명  |
+| `process_type` | 공정 유형   |
+
+후보 이벤트 조회 시 `candidate_event.camera_id`와 연결하여 `zone_name`, `process_type`을 함께 반환함.
+
+---
+
+## `candidate_event`
+
+AI가 탐지한 PPE 미착용 의심 상황을 관리자 검토 전까지 저장하는 테이블임.
+
+| 필드                   | 설명                          |
+| -------------------- | --------------------------- |
+| `event_id`           | 후보 이벤트 식별자                  |
+| `camera_id`          | 이벤트가 발생한 카메라 ID             |
+| `tracking_id`        | 탐지 객체 추적 ID                 |
+| `ppe_type`           | PPE 유형. 예: `helmet`, `vest` |
+| `timestamp_start`    | 이벤트 시작 시각                   |
+| `timestamp_end`      | 이벤트 종료 시각                   |
+| `duration_sec`       | 이벤트 지속 시간                   |
+| `frame_sample_count` | 판단에 사용된 프레임 수               |
+| `thumbnail_path`     | 검토용 썸네일 상대 경로               |
+| `video_clip_path`    | 영상 클립 또는 참조 영상 상대 경로        |
+| `ai_confidence`      | AI 탐지 신뢰도                   |
+| `person_detected`    | 사람 탐지 여부                    |
+| `ppe_detected`       | PPE 착용 탐지 여부                |
+| `model_version`      | 사용 모델 버전                    |
+| `event_status`       | 검토 상태                       |
+
+### `event_status` 값
+
+| 값           | 의미               |
+| ----------- | ---------------- |
+| `pending`   | 관리자 검토 대기        |
+| `confirmed` | 실제 위반으로 확정       |
+| `hold`      | 추가 확인이 필요한 보류 상태 |
+
+`false_positive`는 상세 이벤트를 유지하지 않고 오탐 집계에 반영한 뒤 후보 이벤트를 삭제하므로, 처리 완료 후 `candidate_event`에 상세 행이 남지 않음.
+
+---
+
+## `event_review`
+
+관리자가 `confirmed` 또는 `hold`로 판단한 검토 결과를 저장함.
+
+| 필드                     | 설명              |
+| ---------------------- | --------------- |
+| `review_id`            | 검토 결과 식별자       |
+| `event_id`             | 검토 대상 후보 이벤트 ID |
+| `reviewer_id`          | 검토 담당자 ID       |
+| `review_result`        | 검토 결과           |
+| `review_reason_code`   | 검토 사유 코드        |
+| `review_time`          | 검토 시각           |
+| `review_comment`       | 검토 의견           |
+| `confirmed_violation`  | 확정 위반 여부        |
+| `second_review_needed` | 2차 검토 필요 여부     |
+
+### `review_result` 값
+
+| 값                | 의미       | 저장 처리                           |
+| ---------------- | -------- | ------------------------------- |
+| `confirmed`      | 실제 위반 확인 | 검토 행 저장 및 이벤트 상태 `confirmed` 갱신 |
+| `hold`           | 판단 보류    | 검토 행 저장 및 이벤트 상태 `hold` 갱신      |
+| `false_positive` | 오탐       | 상세 검토 행을 유지하지 않고 오탐 집계 후 이벤트 삭제 |
+
+---
+
+## `false_positive_aggregate`
+
+관리자가 오탐으로 판단한 이벤트는 상세 기록을 유지하지 않고, 다음 기준으로 집계값만 저장함.
+
+```text
+분기 + 구역 + PPE 유형
+```
+
+| 필드                     | 설명        |
+| ---------------------- | --------- |
+| `aggregate_id`         | 오탐 집계 식별자 |
+| `quarter`              | 대상 분기     |
+| `zone_name`            | 발생 구역     |
+| `ppe_type`             | PPE 유형    |
+| `false_positive_count` | 누적 오탐 건수  |
+| `updated_at`           | 마지막 갱신 시각 |
+
+이 구조를 통해 상세 이미지나 이벤트 데이터를 장기 보존하지 않으면서, 특정 구역 또는 PPE 유형에서 오탐이 반복되는지 통계적으로 확인할 수 있음.
+
+---
+
+# 검토 및 재검토 처리 기준
+
+## 최초 검토
+
+최초 검토는 API의 아래 endpoint에서 처리함.
+
+```http
+POST /api/events/{event_id}/review
+```
+
+| 검토 결과            | DB 처리                                                             |
+| ---------------- | ----------------------------------------------------------------- |
+| `confirmed`      | `event_review` 삽입 후 `candidate_event.event_status = confirmed` 갱신 |
+| `hold`           | `event_review` 삽입 후 `candidate_event.event_status = hold` 갱신      |
+| `false_positive` | `false_positive_aggregate` 반영 후 `candidate_event` 삭제              |
+
+동일한 이벤트에 이미 검토 결과가 존재하면 최초 검토를 다시 저장하지 않음.
+
+---
+
+## 재검토
+
+재검토는 아래 조건 중 하나를 만족하는 이벤트에 대해서만 허용함.
+
+```text
+event_status = hold
+또는
+기존 event_review.second_review_needed = 1
+```
+
+재검토 API:
+
+```http
+PUT /api/events/{event_id}/review
+```
+
+| 재검토 결과           | DB 처리                                                                |
+| ---------------- | -------------------------------------------------------------------- |
+| `confirmed`      | 기존 `event_review` 갱신 후 `candidate_event.event_status = confirmed` 갱신 |
+| `hold`           | 기존 `event_review` 갱신 후 `candidate_event.event_status = hold` 갱신      |
+| `false_positive` | `false_positive_aggregate` 반영 후 `candidate_event` 삭제                 |
+
+`candidate_event`가 삭제되는 경우 FK의 `ON DELETE CASCADE` 정책에 따라 연결된 기존 검토 결과도 함께 삭제됨.
+
+---
+
+# 통계 및 교육 추천 처리
+
+## 분기별 통계
+
+분기별 통계는 지정 분기의 후보 이벤트 및 검토 결과를 기준으로 생성함.
+
+생성 API:
+
+```http
+POST /api/stats/generate?quarter=2026-Q2
+```
+
+조회 API:
+
+```http
+GET /api/stats?quarter=2026-Q2
+```
+
+### 통계 반영 기준
+
+| 통계 항목                  | 기준                                    |
+| ---------------------- | ------------------------------------- |
+| `candidate_count`      | 지정 분기에 저장된 후보 이벤트 수                   |
+| `confirmed_count`      | `event_status = confirmed`인 이벤트 수     |
+| `hold_count`           | `event_status = hold`인 이벤트 수          |
+| `false_positive_count` | `false_positive_aggregate`의 해당 분기 집계값 |
+| PPE 유형별 통계             | 확정 위반 이벤트의 PPE 유형별 집계                 |
+| 구역별 통계                 | 확정 위반 이벤트의 발생 구역별 집계                  |
+| 분기별 추이                 | 확정 위반 이벤트의 PPE 유형별 분기 집계              |
+
+---
+
+## 교육 추천
+
+교육 추천은 관리자 검토 결과 중 `confirmed` 상태인 실제 위반 이벤트만을 기반으로 생성함.
+
+생성 API:
+
+```http
+POST /api/recommendations/generate?quarter=2026-Q2
+```
+
+조회 API:
+
+```http
+GET /api/recommendations?quarter=2026-Q2
+```
+
+### 추천 산정 기준
+
+| 기준                    | 설명                          |
+| --------------------- | --------------------------- |
+| `confirmed_count`     | PPE 유형·구역별 확정 위반 건수         |
+| `repeat_weeks`        | 확정 위반이 발생한 주차 수             |
+| `zone_concentration`  | 전체 확정 위반 중 해당 PPE 유형·구역의 비율 |
+| `process_risk_weight` | 공정 위험도 가중치                  |
+
+현재 추천 생성 로직은 계산된 우선순위 점수를 기준으로 상위 3개 교육 추천을 저장함.
+
+### 현재 동작 관련 주의 사항
+
+현재 통계 생성 로직은 동일 분기의 기존 교육 추천 데이터를 초기화함. 따라서 이미 생성한 교육 추천 결과가 있는 상태에서 통계를 다시 생성한 경우, 최신 교육 추천을 확인하려면 아래 생성 API를 다시 실행해야 함.
+
+```http
+POST /api/recommendations/generate?quarter=2026-Q2
+```
+
+---
+
+# 경고 방송 설정 저장 구조
+
+경고 방송 실행 서비스는 DB에 저장된 설정을 조회하여 메시지 선택, cooldown 판단, TTS 실행 여부 처리에 사용함.
+
+## 방송 기본 설정
+
+`broadcast_setting`은 기본 설정 1건을 관리함.
+
+| 필드                 | 설명                        |
+| ------------------ | ------------------------- |
+| `setting_id`       | 설정 식별자. 현재 기본값은 `DEFAULT` |
+| `enabled`          | 방송 전체 사용 여부               |
+| `default_language` | 기본 방송 언어                  |
+| `cooldown_sec`     | 동일 상황 반복 방송 제한 시간         |
+| `updated_at`       | 마지막 설정 변경 시각              |
+
+## 방송 메시지 템플릿
+
+`broadcast_message_template`은 PPE 유형·구역·언어별 메시지를 저장함.
+
+| 필드            | 설명                       |
+| ------------- | ------------------------ |
+| `template_id` | 메시지 템플릿 식별자              |
+| `setting_id`  | 연결된 방송 설정 ID             |
+| `ppe_type`    | PPE 유형                   |
+| `zone_name`   | 특정 구역명. 빈 문자열이면 전체 구역 대상 |
+| `language`    | 메시지 언어                   |
+| `message`     | 실제 방송 문구                 |
+
+메시지 선택 시 특정 구역 템플릿을 우선 적용하고, 일치하는 특정 구역 메시지가 없으면 `zone_name = ""`인 전체 구역 템플릿을 사용함.
+
+---
+
+# `event_repository.py` 주요 함수
+
+## 후보 이벤트
+
+| 함수                                    | 설명              |
+| ------------------------------------- | --------------- |
+| `get_all_candidate_events()`          | 전체 후보 이벤트 목록 조회 |
+| `get_candidate_event_by_id(event_id)` | 특정 후보 이벤트 단건 조회 |
+| `insert_candidate_event(event)`       | 새 후보 이벤트 저장     |
+| `delete_candidate_event(event_id)`    | 후보 이벤트 삭제       |
+
+## 관리자 검토
+
+| 함수                                 | 설명                       |
+| ---------------------------------- | ------------------------ |
+| `insert_event_review(review)`      | 최초 검토 결과 저장 또는 오탐 집계 처리  |
+| `update_event_review(review)`      | 기존 검토 결과 재검토 갱신 또는 오탐 처리 |
+| `get_review_by_event_id(event_id)` | 특정 이벤트의 검토 결과 조회         |
+
+## 통계 및 교육 추천
+
+| 함수                                            | 설명                     |
+| --------------------------------------------- | ---------------------- |
+| `get_quarterly_stats(quarter)`                | 생성된 분기별 통계 조회          |
+| `generate_quarterly_stats(quarter)`           | 후보 이벤트와 검토 결과 기반 통계 생성 |
+| `get_education_recommendations(quarter)`      | 생성된 교육 추천 조회           |
+| `generate_education_recommendations(quarter)` | 확정 위반 기반 교육 추천 생성      |
+
+## 경고 방송 설정
+
+| 함수                                  | 설명                   |
+| ----------------------------------- | -------------------- |
+| `get_broadcast_settings()`          | 현재 경고 방송 설정 및 템플릿 조회 |
+| `save_broadcast_settings(settings)` | 방송 설정 및 템플릿 저장       |
+
+---
+
+# SQLite Boolean 처리
+
+SQLite에서는 Boolean 값을 별도 타입으로 엄격하게 저장하지 않고 `INTEGER` 값으로 저장함.
+
+| 의미      | 저장값 |
+| ------- | --- |
+| `True`  | `1` |
+| `False` | `0` |
+
+현재 아래 필드에서 Boolean 의미의 정수값을 사용함.
+
+```text
+candidate_event.person_detected
+candidate_event.ppe_detected
+event_review.confirmed_violation
+event_review.second_review_needed
+broadcast_setting.enabled
+```
+
+---
+
+# 실행 및 검증 방법
+
+## 1. DB 초기화
 
 ```bash
 python backend/db/init_db.py
 ```
 
-정상 실행 시 다음과 유사한 메시지가 출력된다.
+정상 실행 시 SQLite DB 파일이 생성됨.
 
 ```text
-Database initialized successfully: .../backend/db/ppe_system.db
+backend/db/ppe_system.db
 ```
 
-### 2. DB 조회 확인
+---
+
+## 2. 기본 데이터 확인
 
 ```bash
 python backend/db/check_db.py
 ```
 
-정상 실행 시 다음 항목을 확인할 수 있다.
+정상 실행 시 카메라 정보와 기본 후보 이벤트 데이터를 확인할 수 있음.
 
-- `camera_info` 테이블
-- `candidate_event` 테이블
-- `event_review` 테이블
-- `CAM_001`, `CAM_002` 카메라 더미 데이터
-- `EVT_0001`, `EVT_0002`, `EVT_0003` 후보 이벤트 더미 데이터
+---
 
-### 3. Repository 함수 테스트
+## 3. 추가 테스트 이벤트 삽입
+
+목록·통계·검토 테스트를 위해 추가 이벤트가 필요한 경우 실행함.
+
+```bash
+python backend/db/seed_events.py
+```
+
+---
+
+## 4. Repository 기본 테스트
 
 ```bash
 python backend/db/test_event_repository.py
 ```
 
-정상 실행 시 다음 흐름을 확인할 수 있다.
+테스트 스크립트 범위에 따라 아래 항목을 확인할 수 있음.
 
-- 후보 이벤트 전체 조회
-- 후보 이벤트 단건 조회
-- 새 후보 이벤트 삽입
-- 담당자 검토 결과 삽입
-- 검토 결과 저장 후 `candidate_event.event_status` 갱신 확인
+* 후보 이벤트 전체 및 단건 조회
+* 후보 이벤트 삽입
+* 검토 결과 저장
+* 이벤트 상태 갱신
 
----
-
-## 주요 테이블
-
-| 테이블 | 역할 |
-|---|---|
-| `camera_info` | 카메라, 촬영 구역, 공정 정보 저장 |
-| `candidate_event` | AI가 생성한 PPE 미착용 후보 이벤트 저장 |
-| `event_review` | 담당자의 검토 결과 저장 |
+재검토 API, 통계·추천 생성, 방송 설정 연동은 Swagger 또는 각 서비스 테스트에서 추가 확인함.
 
 ---
 
-## 주요 함수
+# 현재 구현 범위 및 후속 확장
 
-`event_repository.py`에서 제공하는 함수는 다음과 같다.
+## 현재 구현 범위
 
-| 함수 | 설명 |
-|---|---|
-| `get_all_candidate_events()` | 후보 이벤트 전체 목록 조회 |
-| `get_candidate_event_by_id(event_id)` | 특정 후보 이벤트 단건 조회 |
-| `insert_candidate_event(event)` | 새 후보 이벤트 저장 |
-| `insert_event_review(review)` | 담당자 검토 결과 저장 및 이벤트 상태 갱신 |
-| `get_review_by_event_id(event_id)` | 특정 이벤트의 검토 결과 조회 |
+* 후보 이벤트 및 미디어 경로 저장 구조
+* 관리자 최초 검토 및 재검토 결과 반영
+* 오탐 이벤트의 비식별 집계 및 상세 이벤트 삭제
+* 확정 위반 기반 분기별 통계 생성 및 조회
+* 확정 위반 기반 교육 추천 생성 및 조회
+* 경고 방송 설정 및 메시지 템플릿 저장
 
----
+## 후속 확장 대상
 
-## 상태값 기준
-
-### `candidate_event.event_status`
-
-| 값 | 의미 |
-|---|---|
-| `pending` | 검토 대기 |
-| `confirmed` | 확정 위반 |
-| `false_positive` | 오탐 |
-| `hold` | 판단 보류 |
-
-### `event_review.review_result`
-
-| 값 | 의미 |
-|---|---|
-| `confirmed` | 확정 위반 |
-| `false_positive` | 오탐 |
-| `hold` | 판단 보류 |
-
----
-
-## SQLite Boolean 처리
-
-SQLite에서는 Boolean 값을 별도 타입으로 엄격하게 저장하지 않고 `INTEGER`로 저장한다.
-
-| 의미 | 저장값 |
-|---|---|
-| True | `1` |
-| False | `0` |
-
-따라서 현재 DB에서는 다음 필드를 `1` 또는 `0`으로 저장한다.
-
-- `person_detected`
-- `ppe_detected`
-- `confirmed_violation`
-- `second_review_needed`
+* 서버 측 후보 이벤트 필터링 및 페이지네이션
+* 공정별 위험도 가중치의 실제 기준값 적용
+* 방송 실행 이력 저장
+* cooldown 상태 영구 관리
+* 실제 AI 탐지 결과 기반 데이터 축적 및 분석
 
 ---
 
 ## 주의 사항
 
-- `ppe_system.db`는 로컬에서 생성되는 파일이므로 GitHub에 커밋하지 않는다.
-- `init_db.py`는 `schema.sql`과 `seed.sql`을 실행하여 DB를 초기화한다.
-- 같은 더미 데이터를 여러 번 삽입해도 오류가 나지 않도록 `seed.sql`에는 `INSERT OR IGNORE`를 사용한다.
-- `test_event_repository.py`는 테스트용 이벤트 ID인 `EVT_TEST_0001`과 `RV_TEST_0001`을 사용한다.
-- 테스트를 완전히 초기 상태에서 다시 실행하려면 `ppe_system.db`를 삭제한 뒤 `init_db.py`를 다시 실행하면 된다.
-
----
-
-## 분기별 통계 및 교육 추천 테이블
-
-이번 DB 구조에는 후보 이벤트와 담당자 검토 결과 이후 흐름을 지원하기 위해 다음 테이블을 추가함.
-
-| 테이블 | 설명 |
-|---|---|
-| `quarterly_summary` | 분기별 후보 이벤트, 확정 위반, 오탐, 보류 건수 요약 |
-| `quarterly_ppe_stats` | PPE 유형별 확정 위반 수 및 우선순위 점수 |
-| `quarterly_zone_stats` | 구역별 확정 위반 수 및 우선순위 점수 |
-| `quarterly_trend_stats` | 분기별 helmet/vest 확정 위반 추이 |
-| `education_recommendation` | 분기별 안전교육 추천 결과 및 점수 산정 근거 |
-| `false_positive_aggregate` | 오탐으로 판단된 이벤트의 상세 기록은 삭제하고, 분기·구역·PPE 유형 기준의 비식별 오탐 집계만 저장 |
-
-현재 단계에서는 프론트엔드 Mock 데이터 구조와 유사한 더미 데이터를 삽입하여 API 연동 기반을 검증함.
-
----
-
-## 향후 확장 예정
-
-현재 DB 구축 단계에서는 핵심 테이블 3개만 우선 구현했다.
-
-향후 다음 테이블 및 기능을 추가할 수 있다.
-
-| 항목 | 설명 |
-|---|---|
-| FastAPI 또는 Flask 연동 | 프론트엔드 대시보드와 REST API로 연결 |
-| 후보 이벤트 필터링 | PPE 유형, 구역, 상태, 날짜 기준 조회 |
-| 검토 결과 기반 통계 계산 | 확정 위반, 오탐, 보류 건수 집계 |
+* `ppe_system.db`는 로컬 실행 시 생성되는 파일이므로 Git에 포함하지 않음.
+* 생성된 후보 이벤트 썸네일 및 영상 파일도 Git에 포함하지 않음.
+* 테스트를 초기 상태에서 다시 실행하려면 기존 DB 파일을 삭제한 뒤 `init_db.py`를 다시 실행함.
+* 오탐으로 판단된 이벤트는 상세 이벤트 및 검토 데이터를 유지하지 않고 비식별 집계만 저장함.
+* 통계와 교육 추천은 생성 API 실행 이후 조회 가능함.
+* 현재 후보 이벤트 서버 측 필터 API는 `main`에 통합되지 않았으며, 프론트엔드 화면 필터링으로 시연 기능을 제공함.

--- a/backend/db/event_repository.py
+++ b/backend/db/event_repository.py
@@ -448,6 +448,110 @@ def insert_event_review(review: dict[str, Any]) -> None:
             )
 
         conn.commit()
+        
+
+def update_event_review(review: dict[str, Any]) -> None:
+    """
+    기존 담당자 검토 결과를 재검토 결과로 갱신함.
+
+    Args:
+        review (dict[str, Any]):
+            갱신할 검토 결과 정보.
+
+    Required keys:
+        - review_id
+        - event_id
+        - reviewer_id
+        - review_result
+        - review_reason_code
+        - review_time
+        - review_comment
+        - confirmed_violation
+        - second_review_needed
+
+    Notes:
+        - confirmed, hold는 기존 event_review 행을 갱신하고
+          candidate_event.event_status를 함께 갱신함.
+        - false_positive는 기존 정책에 따라 비식별 오탐 집계에 반영한 뒤
+          candidate_event를 삭제함.
+        - candidate_event 삭제 시 ON DELETE CASCADE에 의해
+          기존 event_review 행도 함께 삭제됨.
+    """
+    review_query = """
+        UPDATE event_review
+        SET
+            reviewer_id = :reviewer_id,
+            review_result = :review_result,
+            review_reason_code = :review_reason_code,
+            review_time = :review_time,
+            review_comment = :review_comment,
+            confirmed_violation = :confirmed_violation,
+            second_review_needed = :second_review_needed
+        WHERE event_id = :event_id;
+    """
+
+    status_query = """
+        UPDATE candidate_event
+        SET event_status = :event_status
+        WHERE event_id = :event_id;
+    """
+
+    with get_connection() as conn:
+        existing_review = conn.execute(
+            """
+            SELECT review_id
+            FROM event_review
+            WHERE event_id = ?;
+            """,
+            (review["event_id"],),
+        ).fetchone()
+
+        if existing_review is None:
+            raise ValueError("Review does not exist")
+
+        if review["review_result"] == "false_positive":
+            event = conn.execute(
+                """
+                SELECT
+                    ce.event_id,
+                    ci.zone_name,
+                    ce.ppe_type,
+                    ce.timestamp_start
+                FROM candidate_event ce
+                LEFT JOIN camera_info ci
+                    ON ce.camera_id = ci.camera_id
+                WHERE ce.event_id = ?;
+                """,
+                (review["event_id"],),
+            ).fetchone()
+
+            if event is None:
+                raise ValueError("Event does not exist")
+
+            _upsert_false_positive_aggregate(conn, event)
+
+            conn.execute(
+                """
+                DELETE FROM candidate_event
+                WHERE event_id = ?;
+                """,
+                (review["event_id"],),
+            )
+        else:
+            cursor = conn.execute(review_query, review)
+
+            if cursor.rowcount == 0:
+                raise ValueError("Review does not exist")
+
+            conn.execute(
+                status_query,
+                {
+                    "event_status": review["review_result"],
+                    "event_id": review["event_id"],
+                },
+            )
+
+        conn.commit()
 
 
 def get_review_by_event_id(event_id: str) -> Optional[dict[str, Any]]:

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -1,19 +1,23 @@
 # Backend Services
 
-백엔드 서비스 계층은 AI 탐지 결과를 후보 이벤트 데이터로 변환하고, 저장된 경고 방송 설정에 따라 경고 메시지 출력 및 TTS 음성 방송을 수행하는 역할을 담당함.
+이 폴더는 PPE 분석 시스템의 서비스 계층 코드를 포함함.
+
+서비스 계층은 AI 탐지 결과를 후보 이벤트 데이터로 변환하여 저장하고, 저장된 경고 방송 설정을 기준으로 현장 경고 메시지 출력 및 선택적 TTS 음성 방송을 수행함.
+
+현재 직접 연결된 이벤트 유형은 안전모(`helmet`) 미착용 후보 이벤트이며, 실제 AI 탐지 코드에서는 DB 구조를 직접 다루지 않고 서비스 함수를 호출하는 방식으로 연동함.
 
 ---
 
 ## 파일 구성
 
-| 파일 | 설명 |
-|---|---|
-| `candidate_event_service.py` | AI 탐지 결과를 후보 이벤트로 변환하고 DB 저장 및 경고 방송 실행을 연결함 |
-| `warning_broadcast_service.py` | 방송 설정 조회, 메시지 선택, cooldown 적용, 터미널 로그 및 TTS 실행을 처리함 |
-| `tts_service.py` | 선택된 경고 메시지를 실제 음성으로 출력함 |
-| `test_candidate_event_service.py` | 후보 이벤트 저장 및 썸네일 경로 생성 확인용 수동 테스트 |
-| `test_warning_broadcast_service.py` | 후보 이벤트 저장, 메시지 선택, cooldown, 방송 OFF, TTS 실행 확인용 수동 테스트 |
-| `test_tts_service.py` | 시스템 음성 목록 및 한국어·영어 TTS 단독 출력 확인용 수동 테스트 |
+| 파일                                  | 설명                                                         |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `candidate_event_service.py`        | AI 탐지 결과를 후보 이벤트로 변환하고, 썸네일·영상 참조 경로 저장 및 경고 방송 실행을 연결함    |
+| `warning_broadcast_service.py`      | 방송 설정 조회, 메시지 선택, cooldown 판단, 터미널 로그 출력 및 선택적 TTS 실행을 처리함 |
+| `tts_service.py`                    | 선택된 경고 메시지를 시스템 음성을 이용해 실제 음성으로 출력함                        |
+| `test_candidate_event_service.py`   | 후보 이벤트 저장 및 미디어 경로 생성 확인용 수동 테스트                           |
+| `test_warning_broadcast_service.py` | 후보 이벤트-경고 방송-TTS 연결, cooldown, 방송 OFF, fallback 확인용 수동 테스트 |
+| `test_tts_service.py`               | 시스템 음성 목록 및 한국어·영어 TTS 단독 출력 확인용 수동 테스트                    |
 
 ---
 
@@ -25,7 +29,7 @@
 pip install opencv-python numpy pyttsx3
 ```
 
-또는 `requirements.txt`를 사용하는 경우 아래 항목을 추가함.
+또는 `requirements.txt`에 아래 항목을 포함함.
 
 ```text
 opencv-python
@@ -33,54 +37,79 @@ numpy
 pyttsx3
 ```
 
-| 패키지 | 사용 목적 |
-|---|---|
-| `opencv-python` | 후보 이벤트 썸네일 이미지 저장 |
-| `numpy` | 수동 테스트용 이미지 데이터 생성 |
-| `pyttsx3` | 경고 메시지 TTS 음성 출력 |
+| 패키지             | 사용 목적                  |
+| --------------- | ---------------------- |
+| `opencv-python` | 후보 이벤트 썸네일 이미지 저장      |
+| `numpy`         | 수동 테스트용 프레임 이미지 데이터 생성 |
+| `pyttsx3`       | 로컬 시스템 음성을 이용한 TTS 출력  |
 
 ---
 
-# Candidate Event Media Service
+# 전체 처리 흐름
 
-## 개요
-
-`candidate_event_service.py`는 AI 탐지 결과를 `candidate_event` DB 구조에 맞게 변환하고 저장하는 서비스임.
-
-현재는 안전모 미착용 후보 이벤트 생성을 기준으로 구현되어 있으며, 후보 이벤트 저장 이후 경고 방송 실행 서비스까지 연결함.
-
-## 주요 기능
-
-- 후보 이벤트 ID 생성
-- 이벤트 썸네일 이미지 저장
-- 영상 또는 참조 클립 경로 정리
-- `candidate_event` DB 저장
-- 저장된 이벤트의 구역 정보 조회
-- 후보 이벤트 저장 후 경고 방송 실행 연결
-
-## 처리 흐름
+현재 서비스 계층은 아래 흐름을 지원함.
 
 ```text
 AI 안전모 미착용 탐지
+→ create_no_helmet_candidate_event() 호출
 → 후보 이벤트 ID 생성
-→ 썸네일 이미지 저장
-→ 영상 참조 경로 정리
+→ 탐지 프레임 썸네일 저장
+→ 원본 영상 또는 참조 영상 경로 정리
 → candidate_event DB 저장
-→ 저장된 이벤트의 zone_name 조회
-→ 경고 방송 실행 서비스 호출
+→ 이벤트 발생 구역 조회
+→ 경고 방송 설정 조회
+→ PPE 유형·구역·언어에 맞는 메시지 선택
+→ cooldown 확인
+→ 터미널 경고 로그 출력
+→ enable_tts=True인 경우 TTS 음성 출력
 ```
 
-## 사용 예시
+후보 이벤트 저장은 관리자 확정 이전의 `pending` 상태로 이루어지며, 경고 방송은 사고 예방을 위한 즉시 알림이므로 관리자 검토 이전에 실행됨.
+
+---
+
+# Candidate Event Service
+
+## 개요
+
+`candidate_event_service.py`는 AI 탐지 결과를 `candidate_event` DB 구조에 맞게 변환하고 저장하는 연결 계층임.
+
+AI 담당 코드는 후보 이벤트 DB 필드를 직접 구성하거나 `insert_candidate_event()`를 직접 호출하지 않고, 이 서비스 함수를 호출하여 탐지 결과를 전달하는 방식으로 연동함.
+
+## 현재 제공 함수
+
+```python
+from backend.services.candidate_event_service import create_no_helmet_candidate_event
+```
+
+현재 실제 이벤트 생성 흐름과 직접 연결된 함수는 안전모 미착용 후보 이벤트를 생성하는 `create_no_helmet_candidate_event()`임.
+
+## 주요 기능
+
+* 후보 이벤트 ID 생성
+* 탐지 프레임 기반 썸네일 이미지 저장
+* 원본 영상 또는 참조 영상 경로 정리
+* `candidate_event` DB 저장
+* 저장된 이벤트의 구역 정보 조회
+* 후보 이벤트 저장 직후 경고 방송 실행 연결
+* `enable_tts` 값에 따른 실제 음성 출력 여부 제어
+
+---
+
+## AI 코드 연동 예시
 
 ```python
 from backend.services.candidate_event_service import create_no_helmet_candidate_event
 
 saved_event = create_no_helmet_candidate_event(
     camera_id="CAM_001",
-    confidence=0.88,
-    source_path="test_videos/test_video1.avi",
+    confidence=max_no_helmet_confidence,
+    source_path=source_name,
     frame_image=result.orig_img,
     model_version="helmet_yolov8n",
+    duration_sec=duration_sec,
+    frame_sample_count=frame_sample_count,
+    tracking_id=tracking_id,
     enable_tts=True,
 )
 
@@ -88,38 +117,74 @@ print(saved_event["event_id"])
 print(saved_event["broadcast"])
 ```
 
-`enable_tts` 값에 따라 실제 음성 출력 여부를 제어할 수 있음.
+## 전달값 기준
+
+| 인자                   | 설명                          |
+| -------------------- | --------------------------- |
+| `camera_id`          | 탐지 영상에 대응하는 카메라 ID          |
+| `confidence`         | 안전모 미착용 탐지 신뢰도              |
+| `source_path`        | 원본 영상, 추론 결과 영상 또는 참조 파일 경로 |
+| `frame_image`        | 검토용 썸네일로 저장할 탐지 프레임 이미지     |
+| `model_version`      | 탐지에 사용한 모델 버전               |
+| `timestamp_start`    | 이벤트 시작 시각                   |
+| `timestamp_end`      | 이벤트 종료 시각                   |
+| `duration_sec`       | 미착용 상태 지속 시간                |
+| `frame_sample_count` | 이벤트 판단에 사용한 프레임 수           |
+| `tracking_id`        | 탐지 객체 추적 ID                 |
+| `enable_tts`         | 실제 음성 경고 방송 실행 여부           |
+
+---
+
+## TTS 실행 여부 제어
+
+`enable_tts=True`인 경우 후보 이벤트 저장 후 터미널 로그와 실제 음성 방송을 모두 수행함.
 
 ```python
-# 실제 음성 방송까지 수행
-create_no_helmet_candidate_event(
+saved_event = create_no_helmet_candidate_event(
     camera_id="CAM_001",
     confidence=0.88,
     enable_tts=True,
 )
+```
 
-# 터미널 로그만 출력
-create_no_helmet_candidate_event(
+`enable_tts=False`인 경우 후보 이벤트 저장과 터미널 경고 로그 출력은 수행하지만, 실제 TTS 음성 출력은 수행하지 않음.
+
+```python
+saved_event = create_no_helmet_candidate_event(
     camera_id="CAM_001",
     confidence=0.88,
     enable_tts=False,
 )
 ```
 
+이 값은 테스트, 개발 환경, 실제 시연 상황에 따라 음성 출력 여부를 제어하기 위해 사용함.
+
+---
+
 ## 저장 경로
 
-AI 탐지 결과로 생성된 후보 이벤트의 썸네일과 영상 참조 파일은 학습 데이터와 분리하기 위해 `storage/candidate_events` 아래에 저장함.
+후보 이벤트 관련 미디어 파일은 학습 데이터와 분리하여 `storage/candidate_events` 아래에 저장함.
 
-| 경로 | 설명 |
-|---|---|
-| `storage/candidate_events/thumbnails` | 후보 이벤트 검토용 썸네일 이미지 |
-| `storage/candidate_events/clips` | 후보 이벤트 검토용 영상 클립 또는 참조 영상 |
+| 경로                                    | 설명                          |
+| ------------------------------------- | --------------------------- |
+| `storage/candidate_events/thumbnails` | 후보 이벤트 검토용 썸네일 이미지          |
+| `storage/candidate_events/clips`      | 후보 이벤트 영상 클립 또는 참조 영상 저장 경로 |
 
-실제 생성되는 이미지와 영상 파일은 Git에 포함하지 않고, `.gitkeep`만 유지함.
+썸네일 이미지가 생성되는 경우 DB의 `thumbnail_path`에는 프로젝트 루트 기준 상대 경로를 저장함.
 
-## 수동 테스트 방법
+```text
+storage/candidate_events/thumbnails/EVT_20260519160059_b95d63.jpg
+```
 
-프로젝트 루트에서 DB 초기화 후 후보 이벤트 저장 테스트를 실행함.
+현재 단계에서는 이벤트 발생 전후 구간을 잘라 별도 영상 클립 파일을 생성하기보다, 원본 영상 또는 추론 결과 영상 경로를 `video_clip_path`에 저장하는 구조를 우선 사용함.
+
+생성되는 이미지와 영상 파일은 로컬 실행 산출물이므로 Git에 포함하지 않으며, 폴더 구조 유지를 위한 `.gitkeep`만 관리함.
+
+---
+
+## 후보 이벤트 서비스 수동 테스트
+
+프로젝트 루트에서 아래 순서로 실행함.
 
 ```bash
 python backend/db/init_db.py
@@ -127,18 +192,13 @@ python -m backend.services.test_candidate_event_service
 python backend/db/check_db.py
 ```
 
-정상 동작 시 다음 내용을 확인할 수 있음.
+정상 동작 시 아래 항목을 확인할 수 있음.
 
-- `storage/candidate_events/thumbnails` 아래에 테스트 썸네일 이미지 생성
-- `candidate_event` 테이블에 새 후보 이벤트 저장
-- `thumbnail_path`에 프로젝트 기준 상대 경로 저장
-- `video_clip_path`에 참조 영상 경로 저장
-
-## 참고 사항
-
-현재 단계에서는 실제 짧은 클립 파일을 새로 생성하기보다, 원본 영상 또는 추론 결과 영상 경로를 `video_clip_path`에 저장하는 구조를 우선 사용함.
-
-짧은 영상 클립 생성 기능은 이후 `_save_clip()` 함수 등을 추가하여 확장 가능함.
+* 후보 이벤트 ID 생성
+* `candidate_event` 테이블에 신규 이벤트 저장
+* 썸네일 이미지 생성 및 상대 경로 저장
+* 영상 참조 경로 저장
+* 저장된 이벤트 정보 조회 가능
 
 ---
 
@@ -146,46 +206,53 @@ python backend/db/check_db.py
 
 ## 개요
 
-`warning_broadcast_service.py`는 저장된 경고 방송 설정을 조회하고, PPE 미착용 후보 이벤트에 맞는 경고 메시지를 선택하여 터미널 로그와 TTS 음성 방송을 실행하는 서비스임.
+`warning_broadcast_service.py`는 DB에 저장된 경고 방송 설정을 조회하고, PPE 미착용 후보 이벤트에 맞는 메시지를 선택하여 터미널 로그와 선택적 TTS 음성 방송을 실행하는 서비스임.
+
+경고 방송은 관리자 검토 결과와 무관하게, 후보 이벤트가 발생한 시점에 즉시 시정 알림을 제공하기 위한 흐름으로 동작함.
 
 ## 주요 기능
 
-- 방송 사용 여부(`enabled`) 확인
-- 기본 언어(`default_language`) 기준 메시지 선택
-- PPE 유형 및 구역별 메시지 템플릿 선택
-- 특정 구역 템플릿이 없을 경우 전체 구역 템플릿 적용
-- cooldown 시간 내 동일 상황의 중복 방송 방지
-- 터미널 로그 출력
-- 선택적으로 TTS 음성 출력
-- 방송 실행 결과를 dict 형태로 반환
+* 방송 사용 여부(`enabled`) 확인
+* 기본 방송 언어(`default_language`) 적용
+* PPE 유형·구역·언어 기준 메시지 템플릿 선택
+* 특정 구역 메시지가 없는 경우 전체 구역 메시지 fallback
+* cooldown 시간 내 동일 상황 반복 방송 차단
+* 터미널 로그 출력
+* `enable_tts=True`인 경우 실제 TTS 음성 출력
+* TTS 실패 시에도 터미널 로그 fallback 유지
+* 방송 실행 결과를 dict 형태로 반환
+
+---
 
 ## 방송 설정 연동 기준
 
-경고 방송 실행 서비스는 방송 설정 API를 통해 저장된 다음 값을 사용함.
+경고 방송 서비스는 방송 설정 API를 통해 저장된 아래 값을 사용함.
 
-| 설정값 | 사용 목적 |
-|---|---|
-| `enabled` | 경고 방송 전체 사용 여부 확인 |
-| `default_language` | 기본 방송 언어 선택 |
-| `cooldown_sec` | 동일 상황의 반복 방송 제한 시간 |
-| `templates` | PPE 유형·구역·언어별 경고 메시지 선택 |
+| 설정값                | 설명                       |
+| ------------------ | ------------------------ |
+| `enabled`          | 전체 경고 방송 사용 여부           |
+| `default_language` | 기본 방송 언어                 |
+| `cooldown_sec`     | 동일 상황에 대한 반복 방송 제한 시간    |
+| `templates`        | PPE 유형·구역·언어별 메시지 템플릿 목록 |
 
-메시지 템플릿은 다음 기준으로 관리됨.
+메시지 템플릿은 아래 값으로 구성됨.
 
-```text
-ppe_type
-zone_name
-language
-message
-```
+| 항목          | 설명                          |
+| ----------- | --------------------------- |
+| `ppe_type`  | PPE 유형. 예: `helmet`, `vest` |
+| `zone_name` | 특정 구역명. 빈 문자열이면 전체 구역 대상    |
+| `language`  | 방송 언어. 예: `ko`, `en`        |
+| `message`   | 실제 경고 방송 문구                 |
+
+---
 
 ## 메시지 선택 우선순위
 
-동일한 PPE 유형과 언어에 대해 특정 구역용 템플릿과 전체 구역용 템플릿이 함께 존재할 경우, 특정 구역용 메시지를 우선 사용함.
+동일한 PPE 유형과 언어에 대해 특정 구역용 메시지와 전체 구역용 메시지가 함께 존재할 경우, 특정 구역용 메시지를 우선 사용함.
 
 ```text
-1순위: PPE 유형 + 특정 구역 + 언어가 모두 일치하는 템플릿
-2순위: PPE 유형 + 전체 구역("") + 언어가 일치하는 템플릿
+1순위: PPE 유형 + 특정 구역 + 언어가 모두 일치하는 메시지
+2순위: PPE 유형 + 전체 구역("") + 언어가 일치하는 메시지
 ```
 
 예시:
@@ -195,24 +262,28 @@ helmet / 프레스 구역 / ko / "프레스 구역 작업자는 안전모 착용
 helmet / ""          / ko / "해당 작업 구역의 작업자는 안전모 착용 상태를 확인해 주세요."
 ```
 
-프레스 구역에서 안전모 미착용 이벤트가 발생하면 특정 구역 메시지를 사용하고, 다른 구역에서 발생하면 전체 구역 메시지를 사용함.
+프레스 구역에서 안전모 미착용 후보 이벤트가 발생하면 특정 구역용 메시지를 사용하고, 그 외 구역에서는 전체 구역용 메시지를 사용할 수 있음.
 
-## 방송 실행 흐름
+---
 
-```text
-후보 이벤트 저장
-→ 저장된 이벤트의 zone_name 조회
-→ 경고 방송 설정 조회
-→ enabled 확인
-→ PPE 유형·구역·언어에 맞는 메시지 선택
-→ cooldown 확인
-→ 터미널 로그 출력
-→ enable_tts=True인 경우 TTS 음성 출력
+## 방송 실행 예시
+
+```python
+from backend.services.warning_broadcast_service import execute_warning_broadcast
+
+result = execute_warning_broadcast(
+    event_id="EVT_TEST",
+    ppe_type="helmet",
+    zone_name="프레스 구역",
+    enable_tts=True,
+)
+
+print(result)
 ```
 
-## 터미널 출력 예시
+---
 
-정상적으로 방송이 실행된 경우:
+## 정상 방송 출력 예시
 
 ```text
 [WARNING BROADCAST]
@@ -227,7 +298,11 @@ tts_result=tts_completed
 tts_voice=Microsoft Heami Desktop - Korean
 ```
 
-cooldown으로 반복 방송이 생략된 경우:
+---
+
+## cooldown 적용 예시
+
+동일 상황이 설정된 cooldown 시간 내 반복되는 경우, 추가 음성 방송을 실행하지 않음.
 
 ```text
 [WARNING BROADCAST SKIPPED]
@@ -241,7 +316,11 @@ cooldown_remaining_sec=25
 executed_at=2026-05-26 20:37:01
 ```
 
-방송 설정이 비활성화된 경우:
+---
+
+## 방송 비활성화 예시
+
+방송 설정의 `enabled` 값이 `false`인 경우 메시지 선택 및 TTS 실행을 수행하지 않음.
 
 ```text
 [WARNING BROADCAST SKIPPED]
@@ -253,11 +332,33 @@ language=ko
 executed_at=2026-05-26 20:37:01
 ```
 
+---
+
+## TTS 실패 fallback 예시
+
+TTS 모듈 로드 또는 음성 엔진 실행 중 오류가 발생하더라도, 후보 이벤트 저장 및 터미널 경고 로그 출력 흐름은 중단되지 않음.
+
+```text
+[WARNING BROADCAST]
+event_id=TEST_TTS_FAILURE_EVENT
+result=broadcast_printed
+ppe_type=helmet
+zone_name=프레스 구역
+language=ko
+message=프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.
+executed_at=2026-05-26 20:47:52
+tts_result=tts_error
+```
+
+이 경우 실제 음성 출력에는 실패했지만, 경고 메시지와 실행 결과는 터미널 로그 및 반환 데이터에서 확인할 수 있음.
+
+---
+
 ## cooldown 처리 기준
 
-현재 cooldown은 실행 중인 프로세스 메모리에서 관리함.
+현재 cooldown 상태는 실행 중인 Python 프로세스 메모리에서 관리함.
 
-동일한 아래 조건의 방송이 cooldown 시간 내 다시 요청되면 음성 방송을 생략함.
+동일한 아래 조합의 방송 요청이 cooldown 시간 내 반복되면 추가 방송을 생략함.
 
 ```text
 ppe_type + zone_name + language
@@ -269,36 +370,47 @@ ppe_type + zone_name + language
 helmet + 프레스 구역 + ko
 ```
 
-cooldown 상태는 프로세스를 종료하거나 `reset_broadcast_cooldown()`을 호출하면 초기화됨.
+cooldown 기록은 아래 상황에서 초기화됨.
 
-## 수동 테스트 방법
+* 서버 또는 테스트 프로세스 재시작
+* `reset_broadcast_cooldown()` 호출
 
-프로젝트 루트에서 DB 초기화 후 경고 방송 서비스 테스트를 실행함.
+현재 단계에서는 시연과 로컬 실행을 위한 메모리 기반 관리 방식을 사용함.
+
+---
+
+## 경고 방송 서비스 수동 테스트
+
+프로젝트 루트에서 아래 순서로 실행함.
 
 ```bash
 python backend/db/init_db.py
 python -m backend.services.test_warning_broadcast_service
 ```
 
-테스트 항목:
+### 테스트 항목
 
-- 후보 이벤트 저장 후 구역별 한국어 메시지 선택 확인
-- 후보 이벤트 저장 후 한국어 TTS 음성 출력 확인
-- 동일 상황 재발생 시 cooldown 기반 반복 방송 차단 확인
-- 기본 언어 변경 시 영어 메시지 템플릿 선택 확인
-- 방송 비활성화 시 방송 실행 생략 확인
+* 후보 이벤트 저장 후 구역별 한국어 메시지 선택 확인
+* 후보 이벤트 저장 후 한국어 TTS 음성 출력 확인
+* 동일 상황 재발생 시 cooldown 기반 반복 방송 차단 확인
+* 기본 언어 변경 시 영어 메시지 템플릿 선택 확인
+* 방송 비활성화 시 방송 실행 생략 확인
+* TTS 예외 발생 시 터미널 로그 fallback 유지 확인
+* 후보 이벤트 생성 시 `enable_tts=False`가 적용되어 실제 음성 출력이 생략되는지 확인
 
-주의 사항:
+### 확인 사항
 
-- 본 테스트는 실제 한국어 TTS 음성을 출력하는 수동 테스트임
-- Windows 환경에서는 설치된 시스템 음성을 사용함
-- 확인 환경에서는 `Microsoft Heami Desktop - Korean` 음성 출력이 정상 동작함
+본 테스트는 실제 한국어 TTS 음성을 출력하는 수동 테스트임.
 
-정상 동작 시 다음 메시지를 확인할 수 있음.
+Windows 환경에서는 설치된 시스템 음성을 사용하며, 확인 환경에서는 아래 한국어 음성 출력이 정상 동작함.
 
 ```text
-tts_result=tts_completed
-tts_voice=Microsoft Heami Desktop - Korean
+Microsoft Heami Desktop - Korean
+```
+
+정상 동작 시 마지막에 아래 메시지를 확인할 수 있음.
+
+```text
 [OK] warning broadcast service test passed.
 ```
 
@@ -314,29 +426,40 @@ tts_voice=Microsoft Heami Desktop - Korean
 
 ## 주요 기능
 
-- 시스템에서 사용 가능한 음성 목록 조회
-- 요청 언어에 맞는 시스템 음성 선택
-- 한국어·영어 경고 메시지 음성 출력
-- TTS 실행 결과 반환
+* 시스템에서 사용 가능한 음성 목록 조회
+* 요청 언어에 맞는 시스템 음성 선택
+* 한국어·영어 경고 메시지 출력
+* 음성 출력 성공 여부 반환
+* 음성 미탐색 또는 엔진 실행 오류 결과 반환
 
-## 실행 방식
+---
 
-`execute_warning_broadcast()` 호출 시 `enable_tts=True`를 전달하면, 터미널 로그 출력 이후 실제 음성 방송을 수행함.
+## TTS 실행 결과
+
+| `reason`          | 의미                            |
+| ----------------- | ----------------------------- |
+| `tts_completed`   | 요청 메시지 음성 출력 완료               |
+| `voice_not_found` | 요청 언어에 맞는 시스템 음성을 찾지 못함       |
+| `tts_error`       | TTS 모듈 로드 또는 음성 엔진 실행 중 오류 발생 |
+
+TTS 실행에 실패하더라도 경고 방송 서비스에서는 실패 결과를 기록하고, 기존 터미널 로그 출력 결과를 유지함.
+
+---
+
+## TTS 단독 실행 예시
 
 ```python
-from backend.services.warning_broadcast_service import execute_warning_broadcast
+from backend.services.tts_service import speak_message
 
-result = execute_warning_broadcast(
-    event_id="EVT_TEST",
-    ppe_type="helmet",
-    zone_name="프레스 구역",
-    enable_tts=True,
+result = speak_message(
+    message="프레스 구역 작업자는 안전모 착용 상태를 확인해 주세요.",
+    language="ko",
 )
 
 print(result)
 ```
 
-방송이 비활성화되어 있거나 cooldown으로 생략되는 경우에는 TTS도 실행되지 않음.
+---
 
 ## TTS 단독 수동 테스트
 
@@ -346,29 +469,73 @@ print(result)
 python -m backend.services.test_tts_service
 ```
 
-테스트 항목:
+### 테스트 항목
 
-- 시스템에 설치된 음성 목록 출력
-- 한국어 경고 메시지 음성 출력
-- 영어 경고 메시지 음성 출력
+* 시스템에 설치된 음성 목록 출력
+* 한국어 경고 메시지 음성 출력
+* 영어 경고 메시지 음성 출력
 
-정상 동작 시 한국어 및 영어 안내 음성이 실제로 출력되고, 마지막에 아래 메시지를 확인할 수 있음.
+정상 동작 시 실제 안내 음성이 출력되고, 마지막에 아래 메시지를 확인할 수 있음.
 
 ```text
 [OK] TTS service test passed.
 ```
 
-## 참고 사항
+## 실행 환경 관련 참고 사항
 
-TTS 음성 품질과 사용 가능한 언어는 실행 환경에 설치된 시스템 음성에 따라 달라질 수 있음.
+* TTS 음성 품질과 사용 가능한 언어는 실행 환경에 설치된 시스템 음성에 따라 달라질 수 있음.
+* Windows 환경에서 한국어 음성이 설치되어 있지 않으면 `voice_not_found` 또는 `tts_error` 결과가 반환될 수 있음.
+* TTS 실행 오류는 후보 이벤트 저장 자체를 실패 처리하지 않으며, 방송 실행 결과의 `tts` 항목을 통해 확인함.
 
-Windows에서 한국어 음성이 설치되어 있지 않은 경우, 한국어 메시지 출력이 실패하거나 사용할 수 있는 음성을 찾지 못할 수 있음.
+---
+
+# AI 담당자 연계 방법
+
+## 연계 대상 함수
+
+AI 탐지 코드에서는 안전모 미착용 후보가 확정되었을 때 아래 함수를 호출함.
+
+```python
+from backend.services.candidate_event_service import create_no_helmet_candidate_event
+```
+
+## 연계 시 주의 사항
+
+AI 코드에서 기존에 아래와 같이 DB 저장을 직접 수행하고 있다면, 서비스 호출 방식으로 교체해야 함.
+
+```python
+from backend.db.event_repository import insert_candidate_event
+```
+
+```python
+event = {
+    # 직접 구성한 후보 이벤트 데이터
+}
+
+insert_candidate_event(event)
+```
+
+위 직접 저장 로직을 유지한 상태에서 `create_no_helmet_candidate_event()`까지 추가 호출하면 동일 탐지 결과가 중복 저장될 수 있음.
+
+## 기대 연계 흐름
+
+```text
+YOLO 안전모 미착용 탐지
+→ confidence 및 탐지 프레임 추출
+→ create_no_helmet_candidate_event() 호출
+→ candidate_event 저장
+→ 썸네일 이미지 저장
+→ 방송 설정 조회
+→ 터미널 경고 로그 출력
+→ 필요 시 TTS 경고 방송 실행
+→ 프론트엔드 검토 화면에서 이벤트 확인
+```
 
 ---
 
 # 전체 수동 테스트 순서
 
-프로젝트 루트에서 아래 순서로 실행함.
+서비스 기능 전체를 확인할 때는 프로젝트 루트에서 아래 순서로 실행함.
 
 ```bash
 python backend/db/init_db.py
@@ -378,35 +545,53 @@ python -m backend.services.test_warning_broadcast_service
 python backend/db/check_db.py
 ```
 
-확인 항목:
+## 확인 항목
 
-- 후보 이벤트 저장 및 썸네일 경로 생성
-- TTS 단독 한국어·영어 음성 출력
-- 후보 이벤트 발생 후 방송 설정 기반 메시지 선택
-- 실제 한국어 TTS 경고 방송 출력
-- cooldown 기반 반복 방송 차단
-- 방송 OFF 설정 적용
+* 후보 이벤트 저장 및 이벤트 ID 생성
+* 썸네일 이미지 및 미디어 참조 경로 저장
+* TTS 단독 한국어·영어 출력
+* 후보 이벤트 발생 후 방송 설정 기반 메시지 선택
+* 실제 한국어 TTS 경고 방송 출력
+* cooldown 기반 반복 방송 차단
+* 방송 OFF 설정 반영
+* TTS 실패 fallback 처리
+* `enable_tts=False` 적용 시 음성 출력 생략
+* 테스트 종료 후 생성된 테스트 후보 이벤트 정리
 
 ---
 
 # 현재 구현 범위 및 후속 확장
 
-## 현재 구현 완료 범위
+## 현재 구현 범위
 
-- 안전모 미착용 후보 이벤트 생성 및 DB 저장
-- 후보 이벤트 썸네일 이미지 저장
-- 미디어 참조 경로 정리
-- 경고 방송 설정값 조회 및 적용
-- PPE 유형·구역·언어별 메시지 선택
-- cooldown 기반 중복 방송 방지
-- 터미널 로그 출력
-- 한국어 TTS 경고 방송 출력 확인
-- 영어 TTS 단독 출력 확인
+* 안전모 미착용 후보 이벤트 생성 및 DB 저장
+* 후보 이벤트 검토용 썸네일 이미지 저장
+* 원본 영상 또는 참조 영상 경로 저장
+* 후보 이벤트 저장 후 경고 방송 실행 서비스 연결
+* 경고 방송 설정값 조회 및 적용
+* PPE 유형·구역·언어 기준 메시지 선택
+* cooldown 기반 중복 방송 방지
+* 터미널 기반 경고 로그 출력
+* 한국어 TTS 경고 방송 출력 확인
+* 영어 TTS 단독 출력 확인
+* TTS 실패 시 터미널 로그 fallback 처리
+* `enable_tts` 값에 따른 실제 음성 출력 여부 제어
 
 ## 후속 확장 대상
 
-- 안전조끼 미착용 이벤트 생성 흐름과 방송 실행 직접 연결
-- 실제 짧은 영상 클립 생성 및 저장
-- 방송 실행 이력 DB 저장
-- 서버 재시작 이후에도 유지되는 cooldown 관리
-- AI 탐지 코드에서 후보 이벤트 저장 서비스 호출 연결
+* 실제 AI 탐지 코드에서 후보 이벤트 저장 서비스 호출 연결
+* 안전조끼(`vest`) 미착용 이벤트 생성 흐름 직접 연결
+* 이벤트 발생 구간 기준 실제 짧은 영상 클립 생성
+* 방송 실행 이력 DB 저장 및 관리자 조회
+* 서버 재시작 이후에도 유지되는 cooldown 관리
+* 현장 방송 장비 또는 별도 알림 장치 연동
+
+---
+
+## 주의 사항
+
+* 현재 실제 후보 이벤트 생성 서비스와 직접 연결된 PPE 유형은 안전모(`helmet`) 미착용임.
+* 안전조끼(`vest`)는 메시지 템플릿 선택 구조와 TTS 출력 테스트 범위에서 사용할 수 있으나, AI 탐지 결과 기반 이벤트 생성 흐름은 후속 확장 대상임.
+* 현재 영상 경로 저장은 실제 클립 생성보다 원본 영상 또는 참조 영상 경로 보존을 우선함.
+* 생성된 썸네일 및 영상 파일은 로컬 실행 산출물이므로 Git에 포함하지 않음.
+* 실제 AI 코드 연동 전에는 수동 테스트 스크립트로 저장·방송·TTS 동작을 검증함.

--- a/backend/services/candidate_event_service.py
+++ b/backend/services/candidate_event_service.py
@@ -227,7 +227,7 @@ def create_no_helmet_candidate_event(
         event_id=event_id,
         ppe_type=event["ppe_type"],
         zone_name=zone_name,
-        enable_tts=True,
+        enable_tts=enable_tts,
     )
 
     return {

--- a/backend/services/test_warning_broadcast_service.py
+++ b/backend/services/test_warning_broadcast_service.py
@@ -1,6 +1,6 @@
 """경고 방송 실행 서비스 수동 테스트 스크립트."""
 
-from typing import Any, Optional
+from typing import Any
 
 import backend.services.warning_broadcast_service as broadcast_service
 from backend.db.event_repository import (
@@ -79,10 +79,17 @@ def mock_failed_tts(message: str, language: str) -> dict[str, Any]:
     }
 
 
+def mock_raised_tts(message: str, language: str) -> dict[str, Any]:
+    """
+    TTS 실행 중 예외가 발생하는 상황을 검증하기 위한 mock 함수.
+    """
+    raise RuntimeError("mock tts engine failure")
+
+
 def run_test() -> None:
     original_settings = get_broadcast_settings()
     original_speak_message = broadcast_service.speak_message
-    created_event_id: Optional[str] = None
+    created_event_ids: list[str] = []
 
     try:
         print("\n[test 1] candidate event 저장 후 구역별 한국어 경고 방송 출력")
@@ -99,6 +106,7 @@ def run_test() -> None:
         )
 
         created_event_id = saved_event["event_id"]
+        created_event_ids.append(created_event_id)
         first_broadcast = saved_event["broadcast"]
 
         assert first_broadcast["executed"] is True
@@ -164,7 +172,7 @@ def run_test() -> None:
         save_broadcast_settings(TEST_SETTINGS_KO)
         reset_broadcast_cooldown()
 
-        broadcast_service.speak_message = mock_failed_tts
+        broadcast_service.speak_message = mock_raised_tts
 
         failed_tts_broadcast = execute_warning_broadcast(
             event_id="TEST_TTS_FAILURE_EVENT",
@@ -182,13 +190,37 @@ def run_test() -> None:
         assert failed_tts_broadcast["tts"]["spoken"] is False
         assert failed_tts_broadcast["tts"]["reason"] == "tts_error"
 
+        print("\n[test 6] candidate event 생성 시 enable_tts=False 적용")
+        save_broadcast_settings(TEST_SETTINGS_KO)
+        reset_broadcast_cooldown()
+
+        silent_event = create_no_helmet_candidate_event(
+            camera_id="CAM_001",
+            confidence=0.88,
+            source_path="test_videos/test_video1.avi",
+            frame_image=None,
+            model_version="helmet_yolov8n",
+            enable_tts=False,
+        )
+
+        silent_event_id = silent_event["event_id"]
+        created_event_ids.append(silent_event_id)
+        silent_broadcast = silent_event["broadcast"]
+
+        assert silent_broadcast["executed"] is True
+        assert silent_broadcast["reason"] == "broadcast_printed"
+        assert silent_broadcast["language"] == "ko"
+        assert "tts" not in silent_broadcast
+
+        delete_candidate_event(silent_event_id)
+
         print("\n[OK] warning broadcast service test passed.")
 
     finally:
         broadcast_service.speak_message = original_speak_message
 
-        if created_event_id is not None:
-            delete_candidate_event(created_event_id)
+        for event_id in created_event_ids:
+            delete_candidate_event(event_id)
 
         save_broadcast_settings(original_settings)
         reset_broadcast_cooldown()

--- a/backend/services/tts_service.py
+++ b/backend/services/tts_service.py
@@ -128,11 +128,15 @@ def speak_message(message: str, language: str) -> dict[str, Any]:
     Returns:
         dict[str, Any]:
             음성 출력 성공 여부와 사용 음성 정보.
+            TTS 모듈 로드 또는 엔진 실행에 실패한 경우에도
+            예외를 전달하지 않고 실패 결과를 반환함.
     """
-    pyttsx3 = _load_pyttsx3()
-    engine = pyttsx3.init()
+    engine = None
 
     try:
+        pyttsx3 = _load_pyttsx3()
+        engine = pyttsx3.init()
+
         voices = engine.getProperty("voices")
         selected_voice = _select_voice(voices, language)
 
@@ -169,4 +173,5 @@ def speak_message(message: str, language: str) -> dict[str, Any]:
         }
 
     finally:
-        engine.stop()
+        if engine is not None:
+            engine.stop()

--- a/backend/services/warning_broadcast_service.py
+++ b/backend/services/warning_broadcast_service.py
@@ -2,16 +2,16 @@
 warning_broadcast_service.py
 
 경고 방송 설정을 조회하고, PPE 미착용 후보 이벤트에 대한
-터미널 기반 경고 방송을 실행하는 서비스 파일.
+경고 메시지 출력 및 선택적 TTS 음성 방송을 실행하는 서비스 파일.
 
-현재 단계의 역할:
+역할:
 - 경고 방송 사용 여부 확인
 - PPE 유형/구역/언어에 맞는 메시지 선택
 - cooldown 기반 중복 방송 방지
-- 터미널 기반 방송 시뮬레이션
+- 터미널 기반 경고 로그 출력
+- 선택적 TTS 음성 출력
+- TTS 실패 시 터미널 로그 fallback 유지
 - 방송 실행 결과 dict 반환
-
-실제 TTS 음성 출력은 후속 단계에서 확장한다.
 """
 
 import math
@@ -133,8 +133,9 @@ def execute_warning_broadcast(
             연결된 후보 이벤트 ID.
         language (Optional[str]):
             강제로 사용할 언어. 지정하지 않으면 기본 방송 언어 사용.
-                    enable_tts (bool):
+        enable_tts (bool):
             True이면 터미널 출력 후 실제 음성 출력을 수행함.
+            False이면 터미널 로그만 출력함.
 
     Returns:
         dict[str, Any]:
@@ -210,10 +211,20 @@ def execute_warning_broadcast(
     _print_broadcast_result(result)
 
     if enable_tts:
-        tts_result = speak_message(
-            message=message,
-            language=selected_language,
-        )
+        try:
+            tts_result = speak_message(
+                message=message,
+                language=selected_language,
+            )
+        except Exception as exc:
+            tts_result = {
+                "spoken": False,
+                "reason": "tts_error",
+                "language": selected_language,
+                "message": message,
+                "error": str(exc),
+            }
+
         result["tts"] = tts_result
 
         print(f"tts_result={tts_result['reason']}")


### PR DESCRIPTION
대응 이슈: issue #76

## 작업 내용

* `PUT /api/events/{event_id}/review` 재검토 API 추가
* `backend/db/event_repository.py`에 기존 검토 결과 갱신 로직 추가
* `hold` 상태 또는 `second_review_needed = true`인 이벤트만 재검토 가능하도록 처리
* 재검토 결과에 따라 `event_review`와 `candidate_event.event_status` 갱신
* `false_positive` 재검토 시 기존 정책에 따라 오탐 집계 반영 후 후보 이벤트 삭제
* API README에 재검토 요청 및 확인 방법 추가

## 확인 내용

Swagger에서 아래 흐름을 확인함.

```text
POST /api/events/EVT_0001/review
→ hold 상태로 최초 검토 저장

PUT /api/events/EVT_0001/review
→ confirmed 결과로 재검토 갱신

GET /api/events/EVT_0001
→ event_status 및 review 결과 변경 확인
```

추가로 아래 예외 처리를 확인함.

* 기존 검토 결과가 없는 이벤트는 재검토 불가
* 재검토 대상이 아닌 이벤트는 `409` 반환
* `false_positive`로 재검토된 이벤트는 삭제 처리됨

## 영향 범위

* `backend/db/event_repository.py`
* `backend/api/main.py`
* `backend/api/README.md`
