### PR TITLE
[TEST] Add event re-review regression tests and backend verification runner

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -629,6 +629,29 @@ http://127.0.0.1:8000/storage/candidate_events/thumbnails/EVT_20260519160059_b95
 
 # 테스트 방법
 
+## 재검토 API 회귀 테스트
+
+`PUT /api/events/{event_id}/review`의 성공·거부·오탐 처리 흐름은 아래 테스트 스크립트로 확인할 수 있음.
+
+```bash
+python backend/db/init_db.py
+python -m backend.api.test_event_rereview_api
+```
+
+### 확인 항목
+
+* `hold` 상태 이벤트를 `confirmed`로 재검토할 수 있는지 확인
+* `second_review_needed = true`인 이벤트를 재검토할 수 있는지 확인
+* 기존 검토 결과가 없는 이벤트의 재검토 요청이 거부되는지 확인
+* 재검토 대상이 아닌 이벤트의 요청이 `409`로 거부되는지 확인
+* `false_positive` 재검토 시 후보 이벤트가 삭제되고 오탐 집계가 반영되는지 확인
+
+정상 실행 시 마지막에 아래 메시지를 확인할 수 있음.
+
+```text
+[OK] event re-review regression tests passed.
+```
+
 ## API 기본 흐름 확인
 
 1. DB 초기화

--- a/backend/api/test_event_rereview_api.py
+++ b/backend/api/test_event_rereview_api.py
@@ -1,12 +1,15 @@
 """
 test_event_rereview_api.py
 
-재검토 API의 정상 처리 흐름을 확인하는 수동 테스트 스크립트.
+재검토 API의 성공·거부·오탐 처리 흐름을 확인하는 수동 테스트 스크립트.
 
 확인 항목:
 1. hold 상태 이벤트를 confirmed로 재검토할 수 있는지 확인
 2. second_review_needed=True인 confirmed 이벤트를 재검토할 수 있는지 확인
-3. 재검토 이후 candidate_event 상태와 event_review 값이 갱신되는지 확인
+3. 기존 review가 없는 이벤트의 재검토 요청이 거부되는지 확인
+4. 재검토 대상이 아닌 이벤트의 재검토 요청이 거부되는지 확인
+5. hold 이벤트를 false_positive로 재검토하면 이벤트가 삭제되고
+   오탐 집계가 증가하는지 확인
 
 실행 전:
     python backend/db/init_db.py
@@ -23,6 +26,7 @@ from backend.api.main import app
 from backend.db.event_repository import (
     delete_candidate_event,
     get_candidate_event_by_id,
+    get_connection,
     get_review_by_event_id,
     insert_candidate_event,
 )
@@ -33,6 +37,9 @@ client = TestClient(app)
 TEST_EVENT_IDS = [
     "EVT_TEST_REREVIEW_HOLD",
     "EVT_TEST_REREVIEW_SECOND",
+    "EVT_TEST_REREVIEW_NO_REVIEW",
+    "EVT_TEST_REREVIEW_NOT_ELIGIBLE",
+    "EVT_TEST_REREVIEW_FALSE_POSITIVE",
 ]
 
 
@@ -71,6 +78,30 @@ def cleanup_test_events() -> None:
     for event_id in TEST_EVENT_IDS:
         if get_candidate_event_by_id(event_id) is not None:
             delete_candidate_event(event_id)
+
+
+def get_false_positive_count(
+    quarter: str,
+    zone_name: str,
+    ppe_type: str,
+) -> int:
+    """지정 조건의 오탐 집계 건수를 조회함."""
+    with get_connection() as conn:
+        row = conn.execute(
+            """
+            SELECT false_positive_count
+            FROM false_positive_aggregate
+            WHERE quarter = ?
+              AND zone_name = ?
+              AND ppe_type = ?;
+            """,
+            (quarter, zone_name, ppe_type),
+        ).fetchone()
+
+    if row is None:
+        return 0
+
+    return int(row["false_positive_count"])
 
 
 def test_hold_event_can_be_confirmed_after_rereview() -> None:
@@ -188,6 +219,168 @@ def test_second_review_needed_event_can_be_rereviewed() -> None:
     print("[PASS] second_review_needed 이벤트를 재검토함")
 
 
+def test_event_without_review_cannot_be_rereviewed() -> None:
+    """기존 review가 없는 이벤트의 재검토 요청이 거부되는지 확인함."""
+    event_id = "EVT_TEST_REREVIEW_NO_REVIEW"
+
+    insert_candidate_event(
+        make_candidate_event(
+            event_id=event_id,
+            tracking_id="TRK_TEST_REREVIEW_NO_REVIEW",
+            timestamp_start="2026-05-28 10:20:00",
+        )
+    )
+
+    response = client.put(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin02",
+            "review_result": "confirmed",
+            "review_reason_code": "confirmed_no_helmet",
+            "review_comment": "재검토 요청",
+            "second_review_needed": False,
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Review does not exist"
+
+    saved_event = get_candidate_event_by_id(event_id)
+    saved_review = get_review_by_event_id(event_id)
+
+    assert saved_event is not None
+    assert saved_event["event_status"] == "pending"
+    assert saved_review is None
+
+    print("[PASS] 기존 review가 없는 이벤트의 재검토 요청을 거부함")
+
+
+def test_confirmed_event_without_second_review_cannot_be_rereviewed() -> None:
+    """재검토 대상이 아닌 confirmed 이벤트 요청이 거부되는지 확인함."""
+    event_id = "EVT_TEST_REREVIEW_NOT_ELIGIBLE"
+
+    insert_candidate_event(
+        make_candidate_event(
+            event_id=event_id,
+            tracking_id="TRK_TEST_REREVIEW_NOT_ELIGIBLE",
+            timestamp_start="2026-05-28 10:30:00",
+        )
+    )
+
+    first_review_response = client.post(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin01",
+            "review_result": "confirmed",
+            "review_reason_code": "confirmed_no_helmet",
+            "review_comment": "위반 확정",
+            "second_review_needed": False,
+        },
+    )
+
+    assert first_review_response.status_code == 200
+
+    rereview_response = client.put(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin02",
+            "review_result": "hold",
+            "review_reason_code": "needs_additional_check",
+            "review_comment": "재검토 요청",
+            "second_review_needed": False,
+        },
+    )
+
+    assert rereview_response.status_code == 409
+    assert rereview_response.json()["detail"] == "Event is not eligible for re-review"
+
+    saved_event = get_candidate_event_by_id(event_id)
+    saved_review = get_review_by_event_id(event_id)
+
+    assert saved_event is not None
+    assert saved_event["event_status"] == "confirmed"
+    assert saved_review is not None
+    assert saved_review["reviewer_id"] == "admin01"
+    assert saved_review["review_result"] == "confirmed"
+
+    print("[PASS] 재검토 대상이 아닌 confirmed 이벤트 요청을 거부함")
+
+
+def test_false_positive_rereview_deletes_event_and_updates_aggregate() -> None:
+    """false_positive 재검토 시 후보 이벤트 삭제 및 오탐 집계를 확인함."""
+    event_id = "EVT_TEST_REREVIEW_FALSE_POSITIVE"
+
+    insert_candidate_event(
+        make_candidate_event(
+            event_id=event_id,
+            tracking_id="TRK_TEST_REREVIEW_FALSE_POSITIVE",
+            timestamp_start="2026-05-28 10:40:00",
+        )
+    )
+
+    saved_event = get_candidate_event_by_id(event_id)
+
+    assert saved_event is not None
+
+    quarter = "2026-Q2"
+    zone_name = saved_event["zone_name"]
+    ppe_type = saved_event["ppe_type"]
+
+    count_before = get_false_positive_count(
+        quarter=quarter,
+        zone_name=zone_name,
+        ppe_type=ppe_type,
+    )
+
+    first_review_response = client.post(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin01",
+            "review_result": "hold",
+            "review_reason_code": "needs_additional_check",
+            "review_comment": "오탐 가능성 확인 필요",
+            "second_review_needed": False,
+        },
+    )
+
+    assert first_review_response.status_code == 200
+    assert first_review_response.json()["event"]["event_status"] == "hold"
+
+    rereview_response = client.put(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin02",
+            "review_result": "false_positive",
+            "review_reason_code": "false_detection",
+            "review_comment": "재검토 결과 오탐",
+            "second_review_needed": False,
+        },
+    )
+
+    assert rereview_response.status_code == 200
+    assert rereview_response.json()["review_result"] == "false_positive"
+
+    deleted_event = get_candidate_event_by_id(event_id)
+    deleted_review = get_review_by_event_id(event_id)
+
+    assert deleted_event is None
+    assert deleted_review is None
+
+    count_after = get_false_positive_count(
+        quarter=quarter,
+        zone_name=zone_name,
+        ppe_type=ppe_type,
+    )
+
+    assert count_after == count_before + 1
+
+    get_response = client.get(f"/api/events/{event_id}")
+    assert get_response.status_code == 404
+    assert get_response.json()["detail"] == "Event not found"
+
+    print("[PASS] false_positive 재검토 시 이벤트 삭제 및 오탐 집계를 반영함")
+
+
 def main() -> None:
     cleanup_test_events()
 
@@ -198,7 +391,16 @@ def main() -> None:
         print_section("2차 검토 필요 이벤트 재검토")
         test_second_review_needed_event_can_be_rereviewed()
 
-        print("\n[OK] event re-review success case tests passed.")
+        print_section("기존 review 없는 이벤트 재검토 거부")
+        test_event_without_review_cannot_be_rereviewed()
+
+        print_section("재검토 대상이 아닌 이벤트 요청 거부")
+        test_confirmed_event_without_second_review_cannot_be_rereviewed()
+
+        print_section("false_positive 재검토 처리")
+        test_false_positive_rereview_deletes_event_and_updates_aggregate()
+
+        print("\n[OK] event re-review regression tests passed.")
 
     finally:
         cleanup_test_events()

--- a/backend/api/test_event_rereview_api.py
+++ b/backend/api/test_event_rereview_api.py
@@ -1,0 +1,208 @@
+"""
+test_event_rereview_api.py
+
+재검토 API의 정상 처리 흐름을 확인하는 수동 테스트 스크립트.
+
+확인 항목:
+1. hold 상태 이벤트를 confirmed로 재검토할 수 있는지 확인
+2. second_review_needed=True인 confirmed 이벤트를 재검토할 수 있는지 확인
+3. 재검토 이후 candidate_event 상태와 event_review 값이 갱신되는지 확인
+
+실행 전:
+    python backend/db/init_db.py
+
+실행:
+    python -m backend.api.test_event_rereview_api
+"""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from backend.api.main import app
+from backend.db.event_repository import (
+    delete_candidate_event,
+    get_candidate_event_by_id,
+    get_review_by_event_id,
+    insert_candidate_event,
+)
+
+
+client = TestClient(app)
+
+TEST_EVENT_IDS = [
+    "EVT_TEST_REREVIEW_HOLD",
+    "EVT_TEST_REREVIEW_SECOND",
+]
+
+
+def print_section(title: str) -> None:
+    """터미널 출력 구분선을 표시함."""
+    print(f"\n=== {title} ===")
+
+
+def make_candidate_event(
+    event_id: str,
+    tracking_id: str,
+    timestamp_start: str,
+) -> dict[str, Any]:
+    """재검토 API 테스트용 후보 이벤트 데이터를 생성함."""
+    return {
+        "event_id": event_id,
+        "camera_id": "CAM_001",
+        "tracking_id": tracking_id,
+        "ppe_type": "helmet",
+        "timestamp_start": timestamp_start,
+        "timestamp_end": timestamp_start,
+        "duration_sec": 3,
+        "frame_sample_count": 72,
+        "thumbnail_path": f"/thumbs/{event_id.lower()}.jpg",
+        "video_clip_path": f"/clips/{event_id.lower()}.mp4",
+        "ai_confidence": 0.91,
+        "person_detected": 1,
+        "ppe_detected": 0,
+        "model_version": "yolov8n_v1",
+        "event_status": "pending",
+    }
+
+
+def cleanup_test_events() -> None:
+    """이전 테스트 실행 과정에서 남은 테스트 이벤트를 삭제함."""
+    for event_id in TEST_EVENT_IDS:
+        if get_candidate_event_by_id(event_id) is not None:
+            delete_candidate_event(event_id)
+
+
+def test_hold_event_can_be_confirmed_after_rereview() -> None:
+    """hold 상태 이벤트를 confirmed로 재검토할 수 있는지 확인함."""
+    event_id = "EVT_TEST_REREVIEW_HOLD"
+
+    insert_candidate_event(
+        make_candidate_event(
+            event_id=event_id,
+            tracking_id="TRK_TEST_REREVIEW_HOLD",
+            timestamp_start="2026-05-28 10:00:00",
+        )
+    )
+
+    first_review_response = client.post(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin01",
+            "review_result": "hold",
+            "review_reason_code": "needs_additional_check",
+            "review_comment": "영상 확인 필요",
+            "second_review_needed": False,
+        },
+    )
+
+    assert first_review_response.status_code == 200
+    assert first_review_response.json()["event"]["event_status"] == "hold"
+    assert first_review_response.json()["review"]["review_result"] == "hold"
+
+    rereview_response = client.put(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin02",
+            "review_result": "confirmed",
+            "review_reason_code": "confirmed_no_helmet",
+            "review_comment": "재검토 결과 실제 위반 확인",
+            "second_review_needed": False,
+        },
+    )
+
+    assert rereview_response.status_code == 200
+
+    response_body = rereview_response.json()
+    assert response_body["event"]["event_status"] == "confirmed"
+    assert response_body["review"]["reviewer_id"] == "admin02"
+    assert response_body["review"]["review_result"] == "confirmed"
+    assert response_body["review"]["confirmed_violation"] == 1
+    assert response_body["review"]["second_review_needed"] == 0
+
+    saved_event = get_candidate_event_by_id(event_id)
+    saved_review = get_review_by_event_id(event_id)
+
+    assert saved_event is not None
+    assert saved_event["event_status"] == "confirmed"
+    assert saved_review is not None
+    assert saved_review["review_result"] == "confirmed"
+
+    print("[PASS] hold 이벤트를 confirmed로 재검토함")
+
+
+def test_second_review_needed_event_can_be_rereviewed() -> None:
+    """2차 검토 필요 이벤트를 다시 검토할 수 있는지 확인함."""
+    event_id = "EVT_TEST_REREVIEW_SECOND"
+
+    insert_candidate_event(
+        make_candidate_event(
+            event_id=event_id,
+            tracking_id="TRK_TEST_REREVIEW_SECOND",
+            timestamp_start="2026-05-28 10:10:00",
+        )
+    )
+
+    first_review_response = client.post(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin01",
+            "review_result": "confirmed",
+            "review_reason_code": "confirmed_no_helmet",
+            "review_comment": "2차 확인 필요",
+            "second_review_needed": True,
+        },
+    )
+
+    assert first_review_response.status_code == 200
+    assert first_review_response.json()["event"]["event_status"] == "confirmed"
+    assert first_review_response.json()["review"]["second_review_needed"] == 1
+
+    rereview_response = client.put(
+        f"/api/events/{event_id}/review",
+        json={
+            "reviewer_id": "admin02",
+            "review_result": "hold",
+            "review_reason_code": "needs_additional_check",
+            "review_comment": "추가 영상 확인 보류",
+            "second_review_needed": False,
+        },
+    )
+
+    assert rereview_response.status_code == 200
+
+    response_body = rereview_response.json()
+    assert response_body["event"]["event_status"] == "hold"
+    assert response_body["review"]["reviewer_id"] == "admin02"
+    assert response_body["review"]["review_result"] == "hold"
+    assert response_body["review"]["second_review_needed"] == 0
+
+    saved_event = get_candidate_event_by_id(event_id)
+    saved_review = get_review_by_event_id(event_id)
+
+    assert saved_event is not None
+    assert saved_event["event_status"] == "hold"
+    assert saved_review is not None
+    assert saved_review["review_result"] == "hold"
+
+    print("[PASS] second_review_needed 이벤트를 재검토함")
+
+
+def main() -> None:
+    cleanup_test_events()
+
+    try:
+        print_section("hold 이벤트 confirmed 재검토")
+        test_hold_event_can_be_confirmed_after_rereview()
+
+        print_section("2차 검토 필요 이벤트 재검토")
+        test_second_review_needed_event_can_be_rereviewed()
+
+        print("\n[OK] event re-review success case tests passed.")
+
+    finally:
+        cleanup_test_events()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/db/test_event_repository.py
+++ b/backend/db/test_event_repository.py
@@ -20,6 +20,7 @@ event_repository.py에 작성한 DB 접근 함수들이 정상적으로 작동�
 from datetime import datetime
 
 from event_repository import (
+    delete_candidate_event,
     get_all_candidate_events,
     get_candidate_event_by_id,
     insert_candidate_event,
@@ -33,72 +34,82 @@ def print_section(title: str) -> None:
     print(f"\n=== {title} ===")
 
 
+def cleanup_test_event() -> None:
+    """테스트 과정에서 생성된 후보 이벤트를 삭제함."""
+    if get_candidate_event_by_id("EVT_TEST_0001") is not None:
+        delete_candidate_event("EVT_TEST_0001")
+
+
 def main() -> None:
-    print_section("전체 후보 이벤트 조회")
-    events = get_all_candidate_events()
-    for event in events:
+    cleanup_test_event()
+
+    try:
+        print_section("전체 후보 이벤트 조회")
+        events = get_all_candidate_events()
+        for event in events:
+            print(event)
+
+        print_section("후보 이벤트 단건 조회")
+        event = get_candidate_event_by_id("EVT_0001")
         print(event)
 
-    print_section("후보 이벤트 단건 조회")
-    event = get_candidate_event_by_id("EVT_0001")
-    print(event)
+        print_section("새 후보 이벤트 삽입")
+        new_event = {
+            "event_id": "EVT_TEST_0001",
+            "camera_id": "CAM_001",
+            "tracking_id": "TRK_TEST",
+            "ppe_type": "helmet",
+            "timestamp_start": "2026-04-28 13:00:00",
+            "timestamp_end": "2026-04-28 13:00:03",
+            "duration_sec": 3,
+            "frame_sample_count": 72,
+            "thumbnail_path": "/thumbs/evt_test_0001.jpg",
+            "video_clip_path": "/clips/evt_test_0001.mp4",
+            "ai_confidence": 0.91,
+            "person_detected": 1,
+            "ppe_detected": 0,
+            "model_version": "yolov8n_v1",
+            "event_status": "pending",
+        }
 
-    print_section("새 후보 이벤트 삽입")
-    new_event = {
-        "event_id": "EVT_TEST_0001",
-        "camera_id": "CAM_001",
-        "tracking_id": "TRK_TEST",
-        "ppe_type": "helmet",
-        "timestamp_start": "2026-04-28 13:00:00",
-        "timestamp_end": "2026-04-28 13:00:03",
-        "duration_sec": 3,
-        "frame_sample_count": 72,
-        "thumbnail_path": "/thumbs/evt_test_0001.jpg",
-        "video_clip_path": "/clips/evt_test_0001.mp4",
-        "ai_confidence": 0.91,
-        "person_detected": 1,
-        "ppe_detected": 0,
-        "model_version": "yolov8n_v1",
-        "event_status": "pending",
-    }
-
-    try:
         insert_candidate_event(new_event)
         print("후보 이벤트 삽입 성공")
-    except Exception as error:
-        print(f"후보 이벤트 삽입 생략 또는 실패: {error}")
 
-    print_section("삽입된 후보 이벤트 조회")
-    inserted_event = get_candidate_event_by_id("EVT_TEST_0001")
-    print(inserted_event)
+        print_section("삽입된 후보 이벤트 조회")
+        inserted_event = get_candidate_event_by_id("EVT_TEST_0001")
+        assert inserted_event is not None
+        assert inserted_event["event_status"] == "pending"
+        print(inserted_event)
 
-    print_section("검토 결과 삽입")
-    review = {
-        "review_id": "RV_TEST_0001",
-        "event_id": "EVT_TEST_0001",
-        "reviewer_id": "admin01",
-        "review_result": "confirmed",
-        "review_reason_code": "confirmed_no_helmet",
-        "review_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "review_comment": "테스트용 확정 위반 데이터",
-        "confirmed_violation": 1,
-        "second_review_needed": 0,
-    }
+        print_section("검토 결과 삽입")
+        review = {
+            "review_id": "RV_TEST_0001",
+            "event_id": "EVT_TEST_0001",
+            "reviewer_id": "admin01",
+            "review_result": "confirmed",
+            "review_reason_code": "confirmed_no_helmet",
+            "review_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "review_comment": "테스트용 확정 위반 데이터",
+            "confirmed_violation": 1,
+            "second_review_needed": 0,
+        }
 
-    try:
         insert_event_review(review)
         print("검토 결과 삽입 성공")
-    except Exception as error:
-        print(f"검토 결과 삽입 생략 또는 실패: {error}")
 
-    print_section("검토 결과 조회")
-    inserted_review = get_review_by_event_id("EVT_TEST_0001")
-    print(inserted_review)
+        print_section("검토 결과 조회")
+        inserted_review = get_review_by_event_id("EVT_TEST_0001")
+        assert inserted_review is not None
+        assert inserted_review["review_result"] == "confirmed"
+        print(inserted_review)
 
-    print_section("검토 후 후보 이벤트 상태 확인")
-    updated_event = get_candidate_event_by_id("EVT_TEST_0001")
-    print(updated_event)
+        print_section("검토 후 후보 이벤트 상태 확인")
+        updated_event = get_candidate_event_by_id("EVT_TEST_0001")
+        assert updated_event is not None
+        assert updated_event["event_status"] == "confirmed"
+        print(updated_event)
 
+        print("\n[OK] event repository test passed.")
 
-if __name__ == "__main__":
-    main()
+    finally:
+        cleanup_test_event()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pyttsx3
+httpx

--- a/backend/run_verification.py
+++ b/backend/run_verification.py
@@ -1,0 +1,89 @@
+"""
+백엔드 기능 검증 스크립트를 순서대로 실행하는 runner.
+
+기본 실행:
+    python -m backend.run_verification
+
+실제 음성 출력 포함 실행:
+    python -m backend.run_verification --include-audio
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_command(title: str, command: list[str]) -> None:
+    """검증 명령어를 실행하고 실패 시 전체 runner를 중단함."""
+    print(f"\n{'=' * 60}")
+    print(f"[RUN] {title}")
+    print(f"{'=' * 60}")
+
+    completed = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        check=False,
+    )
+
+    if completed.returncode != 0:
+        raise RuntimeError(f"Verification failed: {title}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run backend verification scripts."
+    )
+    parser.add_argument(
+        "--include-audio",
+        action="store_true",
+        help="Run tests that output actual TTS audio.",
+    )
+    args = parser.parse_args()
+
+    python = sys.executable
+
+    run_command(
+        "Initialize database",
+        [python, "backend/db/init_db.py"],
+    )
+
+    run_command(
+        "Event repository test",
+        [python, "backend/db/test_event_repository.py"],
+    )
+
+    run_command(
+        "Event re-review API regression test",
+        [python, "-m", "backend.api.test_event_rereview_api"],
+    )
+
+    run_command(
+        "Candidate event service test",
+        [python, "-m", "backend.services.test_candidate_event_service"],
+    )
+
+    if args.include_audio:
+        run_command(
+            "TTS service test",
+            [python, "-m", "backend.services.test_tts_service"],
+        )
+
+        run_command(
+            "Warning broadcast service test",
+            [python, "-m", "backend.services.test_warning_broadcast_service"],
+        )
+    else:
+        print(
+            "\n[SKIP] Audio tests skipped. "
+            "Run with --include-audio to verify TTS and warning broadcast output."
+        )
+
+    print("\n[OK] Backend verification completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -533,17 +533,44 @@ YOLO 안전모 미착용 탐지
 
 ---
 
-# 전체 수동 테스트 순서
+# 전체 백엔드 통합 검증
 
-서비스 기능 전체를 확인할 때는 프로젝트 루트에서 아래 순서로 실행함.
+DB, 재검토 API, 후보 이벤트 서비스 기능을 한 번에 확인하려면 아래 runner를 실행함.
+
+## 기본 검증
+
+실제 음성 출력 없이 반복 실행 가능한 검증 흐름을 수행함.
 
 ```bash
-python backend/db/init_db.py
-python -m backend.services.test_candidate_event_service
-python -m backend.services.test_tts_service
-python -m backend.services.test_warning_broadcast_service
-python backend/db/check_db.py
+python -m backend.run_verification
 ```
+
+### 기본 검증 범위
+
+* DB 초기화
+* 후보 이벤트 및 검토 repository 동작 확인
+* 재검토 API 성공·거부·오탐 처리 흐름 확인
+* 후보 이벤트 저장 및 썸네일 생성 확인
+
+## 음성 출력 포함 검증
+
+TTS 및 경고 방송까지 포함하여 확인하려면 `--include-audio` 옵션을 사용함.
+
+```bash
+python -m backend.run_verification --include-audio
+```
+
+### 추가 검증 범위
+
+* 한국어·영어 TTS 음성 출력
+* 후보 이벤트 저장 후 경고 방송 출력
+* cooldown 기반 중복 방송 차단
+* 방송 OFF 설정 적용
+* TTS 실패 fallback 처리
+* `enable_tts=False` 적용 시 실제 음성 출력 생략
+
+음성 출력 포함 검증은 실행 환경에 설치된 시스템 음성을 사용하므로, 시연 전 실제 사용 환경에서 최종 확인하는 용도로 사용함.
+
 
 ## 확인 항목
 

--- a/backend/services/test_candidate_event_service.py
+++ b/backend/services/test_candidate_event_service.py
@@ -5,45 +5,67 @@ candidate_event_service 수동 테스트 스크립트.
     python backend/db/init_db.py
 
 실행:
-    python backend/services/test_candidate_event_service.py
+    python -m backend.services.test_candidate_event_service
 """
 
 from pathlib import Path
-import sys
 
 import cv2
 import numpy as np
 
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-sys.path.append(str(PROJECT_ROOT))
-
-from backend.services.candidate_event_service import create_no_helmet_candidate_event
+from backend.db.event_repository import delete_candidate_event
+from backend.services.candidate_event_service import (
+    PROJECT_ROOT,
+    create_no_helmet_candidate_event,
+)
 
 
 def main() -> None:
-    test_image = np.zeros((360, 640, 3), dtype=np.uint8)
+    created_event_id: str | None = None
+    created_thumbnail_path: Path | None = None
 
-    cv2.putText(
-        test_image,
-        "NO HELMET TEST EVENT",
-        (80, 180),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        1,
-        (255, 255, 255),
-        2,
-    )
+    try:
+        test_image = np.zeros((360, 640, 3), dtype=np.uint8)
 
-    result = create_no_helmet_candidate_event(
-        camera_id="CAM_001",
-        confidence=0.88,
-        source_path="test_videos/test_video1.avi",
-        frame_image=test_image,
-        model_version="helmet_yolov8n_test",
-    )
+        cv2.putText(
+            test_image,
+            "NO HELMET TEST EVENT",
+            (80, 180),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1,
+            (255, 255, 255),
+            2,
+        )
 
-    print("[candidate_event_service test]")
-    print(result)
+        result = create_no_helmet_candidate_event(
+            camera_id="CAM_001",
+            confidence=0.88,
+            source_path="test_videos/test_video1.avi",
+            frame_image=test_image,
+            model_version="helmet_yolov8n_test",
+            enable_tts=False,
+        )
+
+        created_event_id = result["event_id"]
+        created_thumbnail_path = PROJECT_ROOT / result["thumbnail_path"]
+
+        assert result["event_status"] == "pending"
+        assert result["thumbnail_path"] != ""
+        assert result["video_clip_path"] == "test_videos/test_video1.avi"
+        assert result["broadcast"]["executed"] is True
+        assert "tts" not in result["broadcast"]
+        assert created_thumbnail_path.exists()
+
+        print("[PASS] 후보 이벤트 및 썸네일 저장을 확인함")
+        print(result)
+        print("\n[OK] candidate event service test passed.")
+
+    finally:
+        if created_event_id is not None:
+            delete_candidate_event(created_event_id)
+
+        if created_thumbnail_path is not None and created_thumbnail_path.exists():
+            created_thumbnail_path.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
관련 기능: issue #76

## 작업 내용

### 1. 이벤트 재검토 API 회귀 테스트 추가

`PUT /api/events/{event_id}/review` 재검토 흐름에 대한 테스트를 추가함.

확인 항목:

* `hold` 상태 이벤트를 `confirmed`로 재검토할 수 있는지 확인
* `second_review_needed = true`인 이벤트를 재검토할 수 있는지 확인
* 기존 검토 결과가 없는 이벤트의 재검토 요청이 거부되는지 확인
* 재검토 대상이 아닌 이벤트의 요청이 `409`로 거부되는지 확인
* `false_positive` 재검토 시 후보 이벤트가 삭제되고 오탐 집계가 반영되는지 확인

### 2. 기존 backend 테스트 반복 실행 안정화

여러 테스트를 연속 실행하거나 반복 실행할 수 있도록 테스트 과정에서 생성되는 임시 데이터와 파일 정리 흐름을 보완함.

* repository 테스트에서 생성한 테스트 이벤트 정리
* 후보 이벤트 서비스 테스트에서 생성한 이벤트 및 썸네일 파일 정리
* 경고 방송 테스트의 중복 삭제 처리 정리
* 후보 이벤트 서비스 테스트에서 실제 음성 출력 없이 저장·썸네일 생성 흐름 검증 가능하도록 구성

### 3. Backend verification runner 추가

DB, API, 서비스 테스트를 하나의 명령으로 실행할 수 있도록 통합 검증 runner를 추가함.

기본 검증:

```bash
python -m backend.run_verification
```

음성 출력 포함 검증:

```bash
python -m backend.run_verification --include-audio
```

### 4. 테스트 실행 방법 문서화

신규 재검토 API 회귀 테스트와 backend 통합 검증 runner 실행 방법을 README에 반영함.

---

## 테스트 방법

### 기본 검증

```bash
python -m backend.run_verification
```

확인 범위:

* DB 초기화
* 후보 이벤트 및 검토 repository 동작
* 이벤트 재검토 API 성공·거부·오탐 처리
* 후보 이벤트 저장 및 썸네일 생성

### 음성 출력 포함 검증

```bash
python -m backend.run_verification --include-audio
```

추가 확인 범위:

* 한국어·영어 TTS 음성 출력
* 후보 이벤트 저장 후 경고 방송 실행
* cooldown 기반 중복 방송 차단
* 방송 OFF 설정 반영
* TTS 실패 fallback 처리
* `enable_tts = False` 적용 시 음성 출력 생략

---

## 목적

최근 추가된 재검토 API와 경고 방송 관련 서비스가 이후 수정 과정에서도 정상 동작하도록 회귀 테스트를 보강하고, 시연 전 백엔드 검증 절차를 한 번에 수행할 수 있도록 정리함.
