### PR TITLE
[FIX] UI 표시 수정 — 사유 코드 한국어, 재검토 버그, 시스템 명칭, .env gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 
 # Python virtual environment
 venv/
+.venv/
+
+# Environment variable files (never commit secrets)
+.env
+.env.*
+!.env.example
 
 # IDE settings
 .idea/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Environment variable files (never commit secrets)
+.env
+.env.*
+!.env.example
+!.env.local
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -13,8 +13,8 @@ export default function Sidebar() {
   return (
     <aside className={styles.sidebar}>
       <div className={styles.logo}>
-        <span className={styles.logoIcon}>🦺</span>
-        <span className={styles.logoText}>PPE 분석 시스템</span>
+        <span className={styles.logoIcon}>🛡️</span>
+        <span className={styles.logoText}>SENTINEL AI</span>
       </div>
       <nav className={styles.nav}>
         {NAV_ITEMS.map((item) => (

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -6,6 +6,9 @@ import { mediaUrl } from '../api/client';
 import type { CandidateEvent, EventReview, ReviewResult, ReviewReasonCode, ReviewRequest } from '../types';
 import styles from './ReviewDetailPage.module.css';
 
+// Flatten all reason options into a lookup map for display (code → Korean label)
+const REASON_LABEL: Record<string, string> = {};
+
 // Reason code options grouped by the review result selection
 const REASON_OPTIONS: Record<ReviewResult, { value: ReviewReasonCode; label: string }[]> = {
   confirmed: [
@@ -24,6 +27,16 @@ const REASON_OPTIONS: Record<ReviewResult, { value: ReviewReasonCode; label: str
     { value: 'hold_other', label: '기타 (보류)' },
   ],
 };
+
+// Populate the lookup map after REASON_OPTIONS is defined
+for (const opts of Object.values(REASON_OPTIONS)) {
+  for (const o of opts) REASON_LABEL[o.value] = o.label;
+}
+
+// Return human-readable Korean label for a stored reason code
+function getReasonLabel(code: string): string {
+  return REASON_LABEL[code] ?? code;
+}
 
 export default function ReviewDetailPage() {
   const { event_id } = useParams<{ event_id: string }>();
@@ -211,8 +224,8 @@ export default function ReviewDetailPage() {
                         : reviewResult === 'false_positive' ? '오탐'
                         : '보류'}
                   </dd>
-                  <dt>사유 코드</dt>
-                  <dd>{existingReview ? existingReview.review_reason_code : reasonCode}</dd>
+                  <dt>판단 사유</dt>
+                  <dd>{existingReview ? getReasonLabel(existingReview.review_reason_code) : getReasonLabel(reasonCode)}</dd>
                   {(existingReview?.review_comment || comment) && (
                     <>
                       <dt>코멘트</dt>
@@ -227,8 +240,9 @@ export default function ReviewDetailPage() {
                 <button className={styles.secondaryBtn} onClick={() => navigate('/review')}>
                   ← 목록으로
                 </button>
-                {/* Allow re-review only for hold or second-review-needed events */}
-                {existingReview && (event?.event_status === 'hold' || existingReview.second_review_needed) && (
+                {/* Allow re-review only for hold or second-review-needed events.
+                    !! converts to boolean to prevent React rendering numeric 0 as text */}
+                {existingReview && !!(event?.event_status === 'hold' || existingReview.second_review_needed) && (
                   <button className={styles.primaryBtn} onClick={handleStartReReview}>
                     🔄 재검토 시작
                   </button>


### PR DESCRIPTION
## 변경 내용

### 수정된 파일
- `frontend/src/pages/ReviewDetailPage.tsx`
- `frontend/src/components/Sidebar.tsx`
- `.gitignore`
- `frontend/.gitignore`

### 주요 변경사항

**1. 재검토 자리 숫자 `0` 렌더링 버그 수정**
`second_review_needed`가 SQLite에서 숫자 0으로 내려올 때 React가 텍스트로 출력하던 문제를 `!!()` boolean 변환으로 해결.

**2. 사유 코드 한국어 레이블 표시**
검토 완료 화면에서 `confirmed_no_helmet` 대신 `안전모 미착용 확인` 등 한국어를 표시하도록 `getReasonLabel()` 함수 추가.

**3. 시스템 명칭 변경**
`PPE 분석 시스템` → `SENTINEL AI`

**4. `.env` gitignore 추가**
루트 및 `frontend/` 양쪽 `.gitignore`에 `.env` / `.env.*` 패턴 추가. `.env.example`은 유지.