### PR TITLE
[FEAT] 구역 목록 동적 추출 및 확정 위반 분기 대비 trend 실제 연동

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,10 +1,10 @@
 import type { FilterState, EventStatus, PpeType } from '../types';
-import { AVAILABLE_ZONES } from '../mock';
 import styles from './FilterBar.module.css';
 
 interface FilterBarProps {
   filters: FilterState;
   onChange: (filters: FilterState) => void;
+  zones: string[];
 }
 
 const PPE_OPTIONS: { value: PpeType; label: string }[] = [
@@ -21,7 +21,7 @@ const STATUS_OPTIONS: { value: EventStatus | 'all'; label: string }[] = [
   { value: 'hold', label: '보류' },
 ];
 
-export default function FilterBar({ filters, onChange }: FilterBarProps) {
+export default function FilterBar({ filters, onChange, zones }: FilterBarProps) {
   const update = (patch: Partial<FilterState>) =>
     onChange({ ...filters, ...patch });
 
@@ -95,9 +95,9 @@ export default function FilterBar({ filters, onChange }: FilterBarProps) {
         />
       </div>
 
-      {/* Zone multi-select as checkboxes */}
+      {/* Zone multi-select as checkboxes — dynamically derived from actual event data */}
       <div className={styles.zoneGroup}>
-        {AVAILABLE_ZONES.map((zone) => (
+        {zones.map((zone) => (
           <label key={zone} className={styles.zoneLabel}>
             <input
               type="checkbox"

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,8 +5,19 @@ import SummaryCard from '../components/SummaryCard';
 import StatusBadge from '../components/StatusBadge';
 import { fetchEvents } from '../api/events';
 import { fetchStats } from '../api/stats';
-import type { CandidateEvent, QuarterlyStats } from '../types';
+import type { CandidateEvent, QuarterlyStats, TrendPoint } from '../types';
 import styles from './HomePage.module.css';
+
+// Compare last two quarters in the trend array and return % change in total confirmed violations.
+// Returns undefined when there is only one (or zero) data point, so the SummaryCard hides the indicator.
+function calcTrend(trend: TrendPoint[]): number | undefined {
+  if (trend.length < 2) return undefined;
+  const prev = trend[trend.length - 2];
+  const curr = trend[trend.length - 1];
+  const prevTotal = prev.helmet + prev.vest;
+  if (prevTotal === 0) return undefined;
+  return Math.round(((curr.helmet + curr.vest - prevTotal) / prevTotal) * 100);
+}
 
 export default function HomePage() {
   const { quarter } = useOutletContext<{ quarter: string }>();
@@ -42,8 +53,8 @@ export default function HomePage() {
       {stats && (
         <div className={styles.cardRow}>
           <SummaryCard label="후보 이벤트" value={stats.summary.candidate_count} sub="AI 추출 총합" />
-          <SummaryCard label="확정 위반" value={stats.summary.confirmed_count} sub="검토 완료" trend={12} />
-          <SummaryCard label="오탐" value={stats.summary.false_positive_count} sub="AI 오탐지" trend={-5} />
+          <SummaryCard label="확정 위반" value={stats.summary.confirmed_count} sub="검토 완료" trend={calcTrend(stats.trend)} />
+          <SummaryCard label="오탐" value={stats.summary.false_positive_count} sub="AI 오탐지" />
           <SummaryCard label="보류" value={stats.summary.hold_count} sub="추가 검토 필요" />
         </div>
       )}

--- a/frontend/src/pages/ReviewListPage.tsx
+++ b/frontend/src/pages/ReviewListPage.tsx
@@ -52,6 +52,11 @@ export default function ReviewListPage() {
 
   const visibleEvents = useMemo(() => sortEvents(applyFilters(events, filters)), [events, filters]);
   const pendingCount = events.filter((e) => e.event_status === 'pending').length;
+  // Extract unique zone names from fetched events for dynamic filter options
+  const availableZones = useMemo(
+    () => [...new Set(events.map((e) => e.zone_name))].sort(),
+    [events]
+  );
 
   return (
     <div className={styles.page}>
@@ -63,7 +68,7 @@ export default function ReviewListPage() {
         </div>
       )}
 
-      <FilterBar filters={filters} onChange={setFilters} />
+      <FilterBar filters={filters} onChange={setFilters} zones={availableZones} />
 
       <div className={styles.tableWrapper}>
         <table className={styles.table}>


### PR DESCRIPTION
## 변경 내용

### 수정된 파일
- `frontend/src/components/FilterBar.tsx`
- `frontend/src/pages/ReviewListPage.tsx`
- `frontend/src/pages/HomePage.tsx`

### 주요 변경사항

**1. 구역 목록 동적 추출**
`FilterBar`의 구역 체크박스를 mock 하드코딩 대신 API로 받아온 이벤트 데이터에서 추출(`useMemo`)하도록 변경.
신규 구역이 추가될 경우 자동 반영됨.

**2. 확정 위반 trend 실제 계산**
`stats.trend` 배열(분기별 helmet/vest 건수)의 최근 2개 항목을 비교해 전분기 대비 % 변화를 계산하는 `calcTrend()` 함수 추가.
하드코딩된 `trend={12}`, `trend={-5}` 제거. 데이터 1개 이하면 지표 숨김.