### PR TITLE
[FIX] H.264 클립 자동 변환으로 크로스브라우저 재생 지원

### DIFF
--- a/backend/services/candidate_event_service.py
+++ b/backend/services/candidate_event_service.py
@@ -14,6 +14,8 @@ AI 탐지 결과를 candidate_event DB 구조에 맞게 변환하고 저장하�
 이 서비스는 AI 탐지 코드에서 직접 DB 구조를 다루지 않도록 하기 위한 연결 계층이다.
 """
 
+import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -142,6 +144,43 @@ def _normalize_media_path(
         return str(path).replace("\\", "/")
 
 
+def _save_clip(event_id: str, source_path: Optional[Union[str, Path]]) -> str:
+    """
+    Convert source video to H.264 MP4 saved under CLIP_DIR for browser compatibility.
+    Falls back to a direct file copy if ffmpeg is unavailable or conversion fails.
+    """
+    if source_path is None:
+        return ""
+
+    src = Path(source_path)
+    if not src.exists():
+        # File not found — store the normalized path reference as-is.
+        return _normalize_media_path(source_path)
+
+    _ensure_media_dirs()
+    dest = CLIP_DIR / f"{event_id}.mp4"
+
+    try:
+        # Re-encode to H.264 so all modern browsers (Chrome/Edge/Safari) can play it.
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-i", str(src),
+                "-vcodec", "libx264",
+                "-acodec", "aac",
+                "-movflags", "+faststart",
+                str(dest),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # ffmpeg unavailable or conversion failed — copy original without re-encoding.
+        shutil.copy2(str(src), str(dest))
+
+    return _to_relative_path(dest)
+
+
 def create_no_helmet_candidate_event(
     *,
     camera_id: str,
@@ -195,7 +234,8 @@ def create_no_helmet_candidate_event(
     end_time = timestamp_end or start_time
 
     thumbnail_path = _save_thumbnail(event_id, frame_image)
-    video_clip_path = _normalize_media_path(source_path)
+    # Convert to H.264 and save to CLIP_DIR for cross-browser playback.
+    video_clip_path = _save_clip(event_id, source_path)
 
     event = {
         "event_id": event_id,


### PR DESCRIPTION
## 개요

YOLO가 저장하는 영상 클립이 mp4v(MPEG-4) 코덱으로 인코딩되어 Chrome/Edge Windows에서 재생되지 않는 문제를 수정합니다.

## 변경 내용

### `backend/services/candidate_event_service.py`

- `_save_clip()` 함수 신규 추가
  - `source_path` 파일이 실제로 존재하면 **ffmpeg subprocess**로 H.264(libx264) + AAC + `-movflags +faststart` 로 재인코딩하여 `CLIP_DIR/{event_id}.mp4` 에 저장
  - ffmpeg 미설치 또는 변환 실패 시 `shutil.copy2` 폴백으로 원본 파일 복사
  - 파일이 없으면 기존 `_normalize_media_path()` 경로 참조만 반환 (하위 호환)
- `create_no_helmet_candidate_event()` 에서 `_normalize_media_path()` → `_save_clip()` 으로 교체
- `import shutil`, `import subprocess` 추가

## 동작 방식

```
YOLO detect → source_path (mp4v) → _save_clip() → ffmpeg H.264 변환 → CLIP_DIR/{event_id}.mp4
                                                   ↓ 실패 시
                                                  shutil.copy2 (원본 복사)
```

DB에 저장되는 `video_clip_path` 는 항상 `storage/candidate_events/clips/{event_id}.mp4` 형태이므로 프론트엔드 `mediaUrl()` 과 백엔드 StaticFiles 마운트 경로가 그대로 호환됩니다.

## 테스트

```bash
# 1. ffmpeg 설치 확인
ffmpeg -version

# 2. 백엔드 실행
cd backend && uvicorn api.main:app --reload

# 3. AI 탐지 실행 (source_path 전달)
python src/realtime_helmet_monitor.py

# 4. 생성된 클립 코덱 확인
ffprobe storage/candidate_events/clips/<event_id>.mp4
# → Video: h264 이어야 함

# 5. 프론트엔드에서 ReviewDetailPage > ▶ 클립 열기 → 재생 확인
```

Resolves #86