### PR TITLE
[FEAT] 인앱 비디오 모달 복원 (blur backdrop)

### DIFF
--- a/frontend/src/pages/ReviewDetailPage.module.css
+++ b/frontend/src/pages/ReviewDetailPage.module.css
@@ -169,6 +169,68 @@
   background: #2c5282;
 }
 
+/* Full-screen video modal with blurred backdrop */
+.videoOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: fadeIn 0.18s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.videoModal {
+  position: relative;
+  width: min(860px, 92vw);
+  background: #1a202c;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+  animation: slideUp 0.2s ease;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.videoPlayer {
+  display: block;
+  width: 100%;
+  max-height: 70vh;
+  background: #000;
+}
+
+.videoCloseBtn {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.15s;
+}
+
+.videoCloseBtn:hover {
+  background: rgba(0, 0, 0, 0.85);
+}
+
 /* Review result toggle buttons */
 .resultButtons {
   display: grid;

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -55,6 +55,17 @@ export default function ReviewDetailPage() {
   const [submitted, setSubmitted] = useState(false);
   // True when the user clicked '재검토 시작' to overwrite an existing hold/second-review
   const [isReReview, setIsReReview] = useState(false);
+  // Controls the full-screen video modal
+  const [videoOpen, setVideoOpen] = useState(false);
+
+  // Close modal on Escape key
+  useEffect(() => {
+    if (!videoOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setVideoOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [videoOpen]);
+
   useEffect(() => {
     if (!event_id) return;
     setLoading(true);
@@ -162,7 +173,7 @@ export default function ReviewDetailPage() {
               <dt>영상 클립</dt>
               <dd>
                 {event.video_clip_path ? (
-                  <button className={styles.clipBtn} onClick={() => window.open(mediaUrl(event.video_clip_path!), '_blank')}>
+                  <button className={styles.clipBtn} onClick={() => setVideoOpen(true)}>
                     ▶ 클립 열기
                   </button>
                 ) : '—'}
@@ -170,6 +181,26 @@ export default function ReviewDetailPage() {
             </dl>
           </div>
         </div>
+
+        {/* Video modal — blurred backdrop, closes on overlay click or Escape */}
+        {videoOpen && event.video_clip_path && (
+          <div
+            className={styles.videoOverlay}
+            onClick={() => setVideoOpen(false)}
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className={styles.videoModal} onClick={(e) => e.stopPropagation()}>
+              <button className={styles.videoCloseBtn} onClick={() => setVideoOpen(false)}>✕</button>
+              <video
+                src={mediaUrl(event.video_clip_path)}
+                controls
+                autoPlay
+                className={styles.videoPlayer}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Right: event details + review form */}
         <div className={styles.infoCol}>


### PR DESCRIPTION
## 개요

`window.open()` 으로 교체됐던 클립 재생 방식을 인앱 블러 모달로 복원합니다.

## 변경 내용

### `frontend/src/pages/ReviewDetailPage.tsx`
- `videoOpen` state 및 Escape 키 이벤트 리스너 복원
- **▶ 클립 열기** 버튼 → `setVideoOpen(true)` 로 모달 열기
- 블러 backdrop 모달 JSX 복원 (overlay 클릭 / ✕ 버튼 / Escape 로 닫기)

### `frontend/src/pages/ReviewDetailPage.module.css`
- `.videoOverlay` (blur backdrop, fadeIn 애니메이션)
- `.videoModal` (slideUp 애니메이션)
- `.videoPlayer`, `.videoCloseBtn` 스타일 복원

## 동작

- **▶ 클립 열기** 클릭 → blur 배경 모달에서 `<video>` 인라인 재생
- 닫기: ✕ 버튼 / 배경 클릭 / Escape 세 가지 방법 지원
- H.264 클립 (백엔드 ffmpeg 변환 적용 시) → Windows Chrome 포함 모든 환경에서 재생 가능